### PR TITLE
Update stage progress calculation

### DIFF
--- a/nfprogress/AddEntryView.swift
+++ b/nfprogress/AddEntryView.swift
@@ -68,13 +68,12 @@ struct AddEntryView: View {
     }
 
     private func addEntry() {
+        let absoluteCount = project.currentProgress + characterCount
+        let newEntry = Entry(date: date, characterCount: absoluteCount)
         if selectedStageIndex > 0 && selectedStageIndex - 1 < project.stages.count {
             let stage = project.stages[selectedStageIndex - 1]
-            let absoluteCount = characterCount + stage.startProgress
-            let newEntry = Entry(date: date, characterCount: absoluteCount)
             stage.entries.append(newEntry)
         } else {
-            let newEntry = Entry(date: date, characterCount: characterCount)
             project.entries.append(newEntry)
         }
         dismiss()

--- a/nfprogress/MenuBarEntryView.swift
+++ b/nfprogress/MenuBarEntryView.swift
@@ -74,7 +74,8 @@ struct MenuBarEntryView: View {
         guard !didSave, isValid else { return false }
         let index = min(max(selectedIndex, 0), projects.count - 1)
         let project = projects[index]
-        let entry = Entry(date: date, characterCount: characterCount)
+        let absoluteCount = project.currentProgress + characterCount
+        let entry = Entry(date: date, characterCount: absoluteCount)
         if selectedStageIndex > 0 && selectedStageIndex - 1 < project.stages.count {
             let stage = project.stages[selectedStageIndex - 1]
             stage.entries.append(entry)

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -197,6 +197,7 @@ struct ProjectDetailView: View {
                         } label: {
                             StageHeaderView(
                                 stage: stage,
+                                project: project,
                                 onEdit: { editingStage = stage },
                                 onDelete: { stageToDelete = stage }
                             )

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -32,3 +32,30 @@ class Stage: Identifiable {
         return Double(currentProgress) / Double(goal)
     }
 }
+
+extension Stage {
+    /// Calculate progress based only on this stage's entries within the given project
+    func currentProgress(in project: WritingProject) -> Int {
+        let sorted = project.sortedEntries
+        let ids = Set(entries.map { $0.id })
+        var last = startProgress
+        var total = 0
+        for entry in sorted {
+            if entry.characterCount < startProgress {
+                last = entry.characterCount
+                continue
+            }
+            if ids.contains(entry.id) {
+                total += entry.characterCount - last
+            }
+            last = entry.characterCount
+        }
+        return max(0, total)
+    }
+
+    /// Percentage progress relative to this stage's goal within the given project
+    func progressPercentage(in project: WritingProject) -> Double {
+        guard goal > 0 else { return 0 }
+        return Double(currentProgress(in: project)) / Double(goal)
+    }
+}

--- a/nfprogress/StageHeaderView.swift
+++ b/nfprogress/StageHeaderView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import SwiftData
 
 /// Header view for displaying a stage with animated progress percentage
 struct StageHeaderView: View {
     @Bindable var stage: Stage
+    @Bindable var project: WritingProject
     var onEdit: () -> Void
     var onDelete: () -> Void
 
@@ -16,6 +18,11 @@ struct StageHeaderView: View {
     /// Minimum and maximum allowed duration
     private let minDuration = 0.4
     private let maxDuration = 2.5
+
+    /// Current progress percentage for this stage within its project
+    private var progress: Double {
+        stage.progressPercentage(in: project)
+    }
 
     /// Update the displayed progress with an animated transition
     private func updateProgress(to newValue: Double) {
@@ -58,13 +65,13 @@ struct StageHeaderView: View {
         }
         .font(.headline)
         .onAppear {
-            updateProgress(to: stage.progressPercentage)
+            updateProgress(to: progress)
         }
-        .onChange(of: stage.progressPercentage) { newValue in
+        .onChange(of: progress) { newValue in
             updateProgress(to: newValue)
         }
         .onReceive(NotificationCenter.default.publisher(for: .projectProgressChanged)) { _ in
-            updateProgress(to: stage.progressPercentage)
+            updateProgress(to: progress)
         }
     }
 }


### PR DESCRIPTION
## Summary
- compute stage progress within project to account for unrelated entries
- pass project to `StageHeaderView` and refresh when stage entries change
- fix stage progress updates to animate when entries are modified

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852b0f16570833396430559beefb43d