### PR TITLE
Fix progress view and navigation

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
   @State private var projectToDelete: WritingProject?
   @State private var showDeleteAlert = false
 
-  var body: some View {
+  private var splitView: some View {
     NavigationSplitView {
       List(selection: $selectedProject) {
         ForEach(projects) { project in
@@ -85,10 +85,14 @@ struct ContentView: View {
     .navigationDestination(for: WritingProject.self) { project in
       ProjectDetailView(project: project)
     }
-    .fileExporter(
-      isPresented: $isExporting,
-      document: exportDocument,
-      contentType: .commaSeparatedText,
+  }
+
+  var body: some View {
+    splitView
+      .fileExporter(
+        isPresented: $isExporting,
+        document: exportDocument,
+        contentType: .commaSeparatedText,
       defaultFilename: exportFileName
     ) { result in
       if case .failure(let error) = result {


### PR DESCRIPTION
## Summary
- factor out startColor and endColor computations in `ProgressCircleView`
- split drawing logic into helper views to avoid heavy expressions

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685322a12a2c8333bfb6aa452cce6efd