### PR TITLE
Implement window sizing defaults

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -25,9 +25,9 @@ struct ContentView: View {
 
   private var splitView: some View {
     NavigationSplitView(sidebar: {
-      List(selection: $selectedProject) {
+      List {
         ForEach(projects) { project in
-          NavigationLink(value: project) {
+          Button(action: { selectedProject = project }) {
             VStack(alignment: .leading) {
               Text(project.title)
                 .font(.headline)
@@ -42,9 +42,9 @@ struct ContentView: View {
             }
             .padding(.vertical, scaledSpacing(1))
             .frame(minHeight: circleHeight + layoutStep(2))
-            .background(Color.clear)
             .listRowInsets(EdgeInsets())
           }
+          .buttonStyle(.plain)
         }
         .onDelete(perform: deleteProjects)
         .onMove(perform: moveProjects)

--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -28,7 +28,8 @@ struct AddEntryView: View {
 
     private let viewSpacing: CGFloat = scaledSpacing(2)
     private let fieldWidth: CGFloat = layoutStep(15)
-    private let minWidth: CGFloat = layoutStep(30)
+    private let minWidth: CGFloat = layoutStep(34)
+    private let minHeight: CGFloat = layoutStep(20)
 
     var body: some View {
         VStack(spacing: viewSpacing) {
@@ -67,7 +68,7 @@ struct AddEntryView: View {
             .scaledPadding(1, .bottom)
         }
         .scaledPadding()
-        .frame(minWidth: minWidth)
+        .frame(minWidth: minWidth, minHeight: minHeight)
         .onDisappear {
             NotificationCenter.default.post(name: .projectProgressChanged, object: nil)
         }

--- a/nfprogress/ProjectViews.swift
+++ b/nfprogress/ProjectViews.swift
@@ -14,7 +14,8 @@ struct AddProjectView: View {
 
     private let viewSpacing: CGFloat = scaledSpacing(2)
     private let fieldWidth: CGFloat = layoutStep(25)
-    private let minWidth: CGFloat = layoutStep(30)
+    private let minWidth: CGFloat = layoutStep(34)
+    private let minHeight: CGFloat = layoutStep(20)
 
     var body: some View {
         VStack(spacing: viewSpacing) {
@@ -44,7 +45,7 @@ struct AddProjectView: View {
             .scaledPadding(1, .bottom)
         }
         .scaledPadding()
-        .frame(minWidth: minWidth)
+        .frame(minWidth: minWidth, minHeight: minHeight)
     }
 
     private func addProject() {

--- a/nfprogress/StageViews.swift
+++ b/nfprogress/StageViews.swift
@@ -13,7 +13,8 @@ struct AddStageView: View {
 
     private let viewSpacing: CGFloat = scaledSpacing(2)
     private let fieldWidth: CGFloat = layoutStep(25)
-    private let minWidth: CGFloat = layoutStep(30)
+    private let minWidth: CGFloat = layoutStep(34)
+    private let minHeight: CGFloat = layoutStep(20)
 
     var body: some View {
         VStack(spacing: viewSpacing) {
@@ -42,7 +43,7 @@ struct AddStageView: View {
                 .scaledPadding(1, .bottom)
         }
         .scaledPadding()
-        .frame(minWidth: minWidth)
+        .frame(minWidth: minWidth, minHeight: minHeight)
     }
 
     private func addStage() {

--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -46,6 +46,7 @@ extension nfprogressApp {
             AddProjectView()
                 .environmentObject(settings)
         }
+        .defaultSize(width: layoutStep(34), height: layoutStep(20))
         .modelContainer(DataController.shared)
 
         WindowGroup(id: "addStage", for: AddStageRequest.self) { binding in
@@ -56,6 +57,7 @@ extension nfprogressApp {
                     .environmentObject(settings)
             }
         }
+        .defaultSize(width: layoutStep(34), height: layoutStep(20))
         .modelContainer(DataController.shared)
 
         WindowGroup(id: "addEntry", for: AddEntryRequest.self) { binding in
@@ -72,6 +74,7 @@ extension nfprogressApp {
                 }
             }
         }
+        .defaultSize(width: layoutStep(34), height: layoutStep(20))
         .modelContainer(DataController.shared)
 
         WindowGroup(id: "editEntry", for: EditEntryRequest.self) { binding in


### PR DESCRIPTION
## Summary
- tweak widths and heights of Add Project/Stage/Entry windows
- set default sizes in window scenes for creation views
- avoid selection highlight in projects list

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_6855831da35083338bb47a08d3b87fed