### PR TITLE
Add window titles

### DIFF
--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -46,6 +46,7 @@ extension nfprogressApp {
             AddProjectView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
+                .windowTitle("nfprogress — " + settings.localized("new_project"))
         }
         .defaultSize(width: layoutStep(35), height: layoutStep(20))
         .modelContainer(DataController.shared)
@@ -57,6 +58,7 @@ extension nfprogressApp {
                 AddStageView(project: project)
                     .environmentObject(settings)
                     .environment(\.locale, settings.locale)
+                    .windowTitle("nfprogress — " + settings.localized("new_stage"))
             }
         }
         .defaultSize(width: layoutStep(35), height: layoutStep(20))
@@ -71,10 +73,12 @@ extension nfprogressApp {
                     AddEntryView(project: project, stage: stage)
                         .environmentObject(settings)
                         .environment(\.locale, settings.locale)
+                        .windowTitle("nfprogress — " + settings.localized("new_entry"))
                 } else {
                     AddEntryView(project: project)
                         .environmentObject(settings)
                         .environment(\.locale, settings.locale)
+                        .windowTitle("nfprogress — " + settings.localized("new_entry"))
                 }
             }
         }
@@ -89,6 +93,7 @@ extension nfprogressApp {
                 EditEntryView(project: project, entry: entry)
                     .environmentObject(settings)
                     .environment(\.locale, settings.locale)
+                    .windowTitle("NFProgress")
             }
         }
         .defaultSize(width: layoutStep(40), height: layoutStep(25))

--- a/nfprogress/WindowTitleModifier.swift
+++ b/nfprogress/WindowTitleModifier.swift
@@ -1,0 +1,31 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+private struct WindowAccessor: NSViewRepresentable {
+    let title: String
+    func makeNSView(context: Context) -> NSView {
+        let nsView = NSView()
+        DispatchQueue.main.async {
+            if let window = nsView.window {
+                window.title = title
+                window.titleVisibility = .visible
+            }
+        }
+        return nsView
+    }
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            nsView.window?.title = title
+            nsView.window?.titleVisibility = .visible
+        }
+    }
+}
+
+extension View {
+    /// Sets the macOS window title for the view's window.
+    func windowTitle(_ title: String) -> some View {
+        self.background(WindowAccessor(title: title))
+    }
+}
+#endif

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -27,6 +27,7 @@ struct nfprogressApp: App {
             ContentView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
+                .windowTitle("NFProgress")
         }
         .modelContainer(DataController.shared)
         .commands { MainMenuCommands() }
@@ -40,6 +41,7 @@ struct nfprogressApp: App {
             MenuBarEntryView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
+                .windowTitle("NFProgress")
         }
         .menuBarExtraStyle(.window)
         .modelContainer(DataController.shared)


### PR DESCRIPTION
## Summary
- show the app name in the window title bar
- localize auxiliary window titles to include their function

## Testing
- `swift test`
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_6856ecbb97648333a214cc3e0da9c7be