### PR TITLE
Fix compile time for project list view

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -51,6 +51,16 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(language.rawValue, forKey: "language") }
     }
 
+    enum ProjectListStyle: String, CaseIterable, Identifiable {
+        case detailed
+        case compact
+        var id: String { rawValue }
+    }
+
+    @Published var projectListStyle: ProjectListStyle {
+        didSet { defaults.set(projectListStyle.rawValue, forKey: "projectListStyle") }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -59,6 +69,8 @@ final class AppSettings: ObservableObject {
         disableAllAnimations = defaults.bool(forKey: "disableAllAnimations")
         let raw = defaults.string(forKey: "language") ?? AppLanguage.system.rawValue
         language = AppLanguage(rawValue: raw) ?? .system
+        let styleRaw = defaults.string(forKey: "projectListStyle") ?? ProjectListStyle.detailed.rawValue
+        projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
     }
 }
 #else
@@ -78,6 +90,15 @@ final class AppSettings {
         didSet { defaults.set(language.rawValue, forKey: "language") }
     }
 
+    enum ProjectListStyle: String {
+        case detailed
+        case compact
+    }
+
+    var projectListStyle: ProjectListStyle {
+        didSet { defaults.set(projectListStyle.rawValue, forKey: "projectListStyle") }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -86,6 +107,8 @@ final class AppSettings {
         disableAllAnimations = defaults.bool(forKey: "disableAllAnimations")
         let raw = defaults.string(forKey: "language") ?? AppLanguage.system.rawValue
         language = AppLanguage(rawValue: raw) ?? .system
+        let styleRaw = defaults.string(forKey: "projectListStyle") ?? ProjectListStyle.detailed.rawValue
+        projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
     }
 }
 #endif

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -29,22 +29,11 @@ struct ContentView: View {
       List {
         ForEach(projects) { project in
           Button(action: { selectedProject = project }) {
-            VStack(alignment: .leading) {
-              Text(project.title)
-                .font(.headline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
-              HStack {
-                Spacer()
-                ProgressCircleView(project: project)
-                  .frame(height: circleHeight)
-                Spacer()
-              }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, scaledSpacing(1))
-            .frame(minHeight: circleHeight + layoutStep(2))
-            .contentShape(Rectangle())
+            projectRow(for: project)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.vertical, scaledSpacing(1))
+              .frame(minHeight: circleHeight + layoutStep(2))
+              .contentShape(Rectangle())
           }
           .listRowInsets(EdgeInsets())
           .buttonStyle(.plain)
@@ -79,6 +68,13 @@ struct ContentView: View {
               importSelectedProject()
             }
           }
+          ToolbarItem {
+            Picker("", selection: $settings.projectListStyle) {
+              Image(systemName: "chart.pie").tag(AppSettings.ProjectListStyle.detailed)
+              Image(systemName: "list.bullet").tag(AppSettings.ProjectListStyle.compact)
+            }
+            .pickerStyle(.segmented)
+          }
         #else
           ToolbarItemGroup(placement: .navigationBarLeading) {
             if selectedProject != nil {
@@ -89,6 +85,13 @@ struct ContentView: View {
             Button("import") {
               importSelectedProject()
             }
+          }
+          ToolbarItem(placement: .navigationBarTrailing) {
+            Picker("", selection: $settings.projectListStyle) {
+              Image(systemName: "chart.pie").tag(AppSettings.ProjectListStyle.detailed)
+              Image(systemName: "list.bullet").tag(AppSettings.ProjectListStyle.compact)
+            }
+            .pickerStyle(.segmented)
           }
         #endif
       }
@@ -102,6 +105,27 @@ struct ContentView: View {
     })
     .navigationDestination(for: WritingProject.self) { project in
       ProjectDetailView(project: project)
+    }
+  }
+
+  @ViewBuilder
+  private func projectRow(for project: WritingProject) -> some View {
+    switch settings.projectListStyle {
+    case .detailed:
+      VStack(alignment: .leading) {
+        Text(project.title)
+          .font(.headline)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .fixedSize(horizontal: false, vertical: true)
+        HStack {
+          Spacer()
+          ProgressCircleView(project: project)
+            .frame(height: circleHeight)
+          Spacer()
+        }
+      }
+    case .compact:
+      CompactProjectRow(project: project)
     }
   }
 

--- a/nfprogress/ProjectListViews.swift
+++ b/nfprogress/ProjectListViews.swift
@@ -1,0 +1,126 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(SwiftData)
+import SwiftData
+#endif
+
+/// Animated percent text for project progress used in compact list view.
+struct ProjectPercentView: View {
+    var project: WritingProject
+
+    @AppStorage("disableLaunchAnimations") private var disableLaunchAnimations = false
+    @AppStorage("disableAllAnimations") private var disableAllAnimations = false
+
+    private var progress: Double {
+        guard project.goal > 0 else { return 0 }
+        let percent = Double(project.currentProgress) / Double(project.goal)
+        return min(max(percent, 0), 1.0)
+    }
+
+    @State private var startProgress: Double = 0
+    @State private var endProgress: Double = 0
+    @State private var duration: Double = 0.25
+
+    private let minDuration = 0.25
+    private let maxDuration = 3.0
+
+    private func color(for percent: Double) -> Color {
+        .interpolate(from: .red, to: .green, fraction: percent)
+    }
+
+    private func updateProgress(to newValue: Double, animated: Bool = true) {
+        guard abs(newValue - endProgress) > 0.0001 else { return }
+        if animated { startProgress = endProgress } else { startProgress = newValue }
+        endProgress = newValue
+        if animated {
+            let diff = abs(endProgress - startProgress)
+            let range = max(diff, 0.01)
+            let scaled = min(range, 1.0)
+            duration = min(minDuration + scaled * (maxDuration - minDuration), maxDuration)
+        } else {
+            duration = 0
+        }
+    }
+
+    @ViewBuilder
+    private func progressText() -> some View {
+        if disableAllAnimations {
+            AnimatedCounterText(value: endProgress)
+                .foregroundColor(color(for: endProgress))
+        } else if #available(macOS 12, *) {
+            AnimatedProgressView(
+                startPercent: startProgress,
+                endPercent: endProgress,
+                startColor: color(for: startProgress),
+                endColor: color(for: endProgress),
+                duration: duration
+            ) { value, color in
+                let percent = Int(ceil(value * 100))
+                return Text("\(percent)%")
+                    .monospacedDigit()
+                    .bold()
+                    .foregroundColor(color)
+            }
+        } else {
+            AnimatedCounterText(value: endProgress)
+                .foregroundColor(color(for: endProgress))
+        }
+    }
+
+    var body: some View {
+        progressText()
+            .scaledFont(.progressValue)
+        .onAppear {
+            let last = ProgressAnimationTracker.lastProgress(for: project)
+            if disableLaunchAnimations || disableAllAnimations {
+                startProgress = progress
+                endProgress = progress
+            } else if let last {
+                startProgress = last
+                endProgress = last
+                if abs(last - progress) > 0.0001 {
+                    DispatchQueue.main.async { updateProgress(to: progress) }
+                }
+            } else {
+                let elapsed = Date().timeIntervalSince(AppLaunch.launchDate)
+                let delay = max(0, 1 - elapsed)
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    updateProgress(to: progress)
+                }
+            }
+            ProgressAnimationTracker.setProgress(progress, for: project)
+        }
+        .onChange(of: progress) { newValue in
+            ProgressAnimationTracker.setProgress(newValue, for: project)
+            updateProgress(to: newValue, animated: !disableAllAnimations)
+        }
+        .onChange(of: project.entries.map { $0.id }) { _ in
+            ProgressAnimationTracker.setProgress(progress, for: project)
+            updateProgress(to: progress, animated: !disableAllAnimations)
+        }
+        .onChange(of: project.stages.flatMap { $0.entries }.map { $0.id }) { _ in
+            ProgressAnimationTracker.setProgress(progress, for: project)
+            updateProgress(to: progress, animated: !disableAllAnimations)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .projectProgressChanged)) { _ in
+            ProgressAnimationTracker.setProgress(progress, for: project)
+            updateProgress(to: progress, animated: !disableAllAnimations)
+        }
+    }
+}
+
+/// Row view showing only project title and progress percentage.
+struct CompactProjectRow: View {
+    var project: WritingProject
+    var body: some View {
+        HStack {
+            Text(project.title)
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+            ProjectPercentView(project: project)
+        }
+        .padding(.vertical, scaledSpacing(1))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- split animated percent view into computed subview to avoid Xcode type-check limit
- replace computed property with function to satisfy Swift type checker
- fix returning view from progressText closure

## Testing
- `swift test --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_6856f0b70da883339b4656b9ca21f9f4