### PR TITLE
Show project title in window title

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -182,6 +182,9 @@ struct ContentView: View {
     .onReceive(NotificationCenter.default.publisher(for: .menuExport)) { _ in
       exportSelectedProject()
     }
+#if os(macOS)
+    .windowTitle(selectedProject?.title ?? "NFProgress")
+#endif
   }
 
   private func addProject() {


### PR DESCRIPTION
## Summary
- update `ContentView` to update the NS window title whenever a project is selected

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6857038aee18833388ed819e5fd878ef