### PR TITLE
Refine project sort button

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -57,8 +57,27 @@ final class AppSettings: ObservableObject {
         var id: String { rawValue }
     }
 
+    enum ProjectSortOrder: String, CaseIterable, Identifiable {
+        case title
+        case progress
+        var id: String { rawValue }
+
+        var iconName: String {
+            switch self {
+            case .title: return "textformat"
+            case .progress: return "chart.bar"
+            }
+        }
+
+        var next: ProjectSortOrder { self == .title ? .progress : .title }
+    }
+
     @Published var projectListStyle: ProjectListStyle {
         didSet { defaults.set(projectListStyle.rawValue, forKey: "projectListStyle") }
+    }
+
+    @Published var projectSortOrder: ProjectSortOrder {
+        didSet { defaults.set(projectSortOrder.rawValue, forKey: "projectSortOrder") }
     }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
@@ -71,6 +90,8 @@ final class AppSettings: ObservableObject {
         language = AppLanguage(rawValue: raw) ?? .system
         let styleRaw = defaults.string(forKey: "projectListStyle") ?? ProjectListStyle.detailed.rawValue
         projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
+        let sortRaw = defaults.string(forKey: "projectSortOrder") ?? ProjectSortOrder.title.rawValue
+        projectSortOrder = ProjectSortOrder(rawValue: sortRaw) ?? .title
     }
 }
 #else
@@ -95,8 +116,26 @@ final class AppSettings {
         case compact
     }
 
+    enum ProjectSortOrder: String {
+        case title
+        case progress
+
+        var iconName: String {
+            switch self {
+            case .title: return "textformat"
+            case .progress: return "chart.bar"
+            }
+        }
+
+        var next: ProjectSortOrder { self == .title ? .progress : .title }
+    }
+
     var projectListStyle: ProjectListStyle {
         didSet { defaults.set(projectListStyle.rawValue, forKey: "projectListStyle") }
+    }
+
+    var projectSortOrder: ProjectSortOrder {
+        didSet { defaults.set(projectSortOrder.rawValue, forKey: "projectSortOrder") }
     }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
@@ -109,6 +148,8 @@ final class AppSettings {
         language = AppLanguage(rawValue: raw) ?? .system
         let styleRaw = defaults.string(forKey: "projectListStyle") ?? ProjectListStyle.detailed.rawValue
         projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
+        let sortRaw = defaults.string(forKey: "projectSortOrder") ?? ProjectSortOrder.title.rawValue
+        projectSortOrder = ProjectSortOrder(rawValue: sortRaw) ?? .title
     }
 }
 #endif

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -73,3 +73,4 @@
 "delete_project_tooltip" = "Delete selected project";
 "export_project_tooltip" = "Export project";
 "import_project_tooltip" = "Import project";
+"toggle_sort_tooltip" = "Change sort order";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -73,3 +73,4 @@
 "delete_project_tooltip" = "Удалить выбранный проект";
 "export_project_tooltip" = "Экспортировать проект";
 "import_project_tooltip" = "Импортировать проект";
+"toggle_sort_tooltip" = "Изменить сортировку";


### PR DESCRIPTION
## Summary
- simplify `ProjectSortOrder` to toggle between title and progress sorting
- provide helper properties for icon and cycling
- adjust list and toolbar button to use new sort order

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68570cfabdac8333bb96b793db6aaad9