### PR TITLE
Fix windowTitle compile issue on iOS

### DIFF
--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -46,7 +46,9 @@ extension nfprogressApp {
             AddProjectView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
+#if os(macOS)
                 .windowTitle("nfprogress — " + settings.localized("new_project"))
+#endif
         }
         .defaultSize(width: layoutStep(35), height: layoutStep(20))
         .modelContainer(DataController.shared)
@@ -58,7 +60,9 @@ extension nfprogressApp {
                 AddStageView(project: project)
                     .environmentObject(settings)
                     .environment(\.locale, settings.locale)
+#if os(macOS)
                     .windowTitle("nfprogress — " + settings.localized("new_stage"))
+#endif
             }
         }
         .defaultSize(width: layoutStep(35), height: layoutStep(20))
@@ -73,12 +77,16 @@ extension nfprogressApp {
                     AddEntryView(project: project, stage: stage)
                         .environmentObject(settings)
                         .environment(\.locale, settings.locale)
+#if os(macOS)
                         .windowTitle("nfprogress — " + settings.localized("new_entry"))
+#endif
                 } else {
                     AddEntryView(project: project)
                         .environmentObject(settings)
                         .environment(\.locale, settings.locale)
+#if os(macOS)
                         .windowTitle("nfprogress — " + settings.localized("new_entry"))
+#endif
                 }
             }
         }
@@ -93,7 +101,9 @@ extension nfprogressApp {
                 EditEntryView(project: project, entry: entry)
                     .environmentObject(settings)
                     .environment(\.locale, settings.locale)
+#if os(macOS)
                     .windowTitle("NFProgress")
+#endif
             }
         }
         .defaultSize(width: layoutStep(40), height: layoutStep(25))

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -27,7 +27,9 @@ struct nfprogressApp: App {
             ContentView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
+#if os(macOS)
                 .windowTitle("NFProgress")
+#endif
         }
         .modelContainer(DataController.shared)
         .commands { MainMenuCommands() }
@@ -41,7 +43,9 @@ struct nfprogressApp: App {
             MenuBarEntryView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
+#if os(macOS)
                 .windowTitle("NFProgress")
+#endif
         }
         .menuBarExtraStyle(.window)
         .modelContainer(DataController.shared)


### PR DESCRIPTION
## Summary
- only apply `.windowTitle` modifier when building for macOS

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6857a7c6aa2c8333ac50c6260936a8e5