### PR TITLE
Fix iOS build by gating macOS-only menu bar

### DIFF
--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -39,16 +39,16 @@ struct nfprogressApp: App {
         }
         #endif
 
+        #if os(macOS)
         MenuBarExtra("NFProgress", systemImage: "text.cursor") {
             MenuBarEntryView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
-#if os(macOS)
                 .windowTitle("NFProgress")
-#endif
         }
         .menuBarExtraStyle(.window)
         .modelContainer(DataController.shared)
+        #endif
 
 #if os(macOS)
         additionalWindows


### PR DESCRIPTION
## Summary
- restrict MenuBarExtra related code to macOS builds

## Testing
- `swift build`
- `swift build --triple x86_64-apple-ios15.0-simulator` *(fails: toolchain is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6857a9a026008333b9590861fdb1d5cb