### PR TITLE
Auto focus entry field on iOS

### DIFF
--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -14,6 +14,9 @@ struct AddEntryView: View {
 
     @State private var date = Date()
     @State private var characterCount = 0
+#if os(iOS)
+    @FocusState private var isCharactersFieldFocused: Bool
+#endif
 
     init(project: WritingProject, stage: Stage? = nil) {
         self.project = project
@@ -55,6 +58,10 @@ struct AddEntryView: View {
             TextField("characters", value: $characterCount, format: .number)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: fieldWidth)
+#if os(iOS)
+                .keyboardType(.numberPad)
+                .focused($isCharactersFieldFocused)
+#endif
                 .submitLabel(.done)
                 .onSubmit(addEntry)
 
@@ -66,9 +73,12 @@ struct AddEntryView: View {
             .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
             .scaledPadding(1, .bottom)
-        }
+        } 
         .scaledPadding()
         .frame(minWidth: minWidth, minHeight: minHeight)
+#if os(iOS)
+        .onAppear { isCharactersFieldFocused = true }
+#endif
     }
 
     private func addEntry() {


### PR DESCRIPTION
## Summary
- focus the character count input when adding a new entry on iOS
- show numeric keypad for character count

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6857cb58a1b08333bf7514f3bb3f6845