### PR TITLE
Select text automatically on mac

### DIFF
--- a/nfprogress/SelectAllIntField.swift
+++ b/nfprogress/SelectAllIntField.swift
@@ -1,0 +1,61 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Numeric text field that focuses automatically and selects its contents when it appears.
+struct SelectAllIntField: View {
+    @Binding var value: Int
+    var placeholder: LocalizedStringKey
+    var focusOnAppear: Bool = false
+
+    @State private var didFocus: Bool = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        TextField(placeholder, value: $value, format: .number)
+            .textFieldStyle(.roundedBorder)
+#if os(iOS)
+            .keyboardType(.numberPad)
+#endif
+            .focused($isFocused)
+            .onAppear {
+                guard focusOnAppear, !didFocus else { return }
+                isFocused = true
+                DispatchQueue.main.async {
+                    selectAll()
+                }
+                didFocus = true
+            }
+    }
+
+#if os(iOS)
+    private func selectAll() {
+        guard let controller = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first(where: { $0.isKeyWindow }),
+              let root = controller.rootViewController else { return }
+
+        selectAll(from: root.view)
+    }
+
+    private func selectAll(from view: UIView) {
+        if let textField = view as? UITextField, textField.isFirstResponder {
+            textField.selectedTextRange = textField.textRange(from: textField.beginningOfDocument,
+                                                             to: textField.endOfDocument)
+        } else {
+            for subview in view.subviews {
+                selectAll(from: subview)
+            }
+        }
+    }
+#elseif os(macOS)
+    private func selectAll() {
+        NSApp.keyWindow?.makeFirstResponder(nil)
+        if let field = NSApp.keyWindow?.firstResponder as? NSTextView {
+            field.selectAll(nil)
+        }
+    }
+#else
+    private func selectAll() {}
+#endif
+}
+#endif


### PR DESCRIPTION
## Summary
- use `SelectAllIntField` for numeric input on mac and iOS
- make `SelectAllIntField` a SwiftUI view that focuses and selects text cross‑platform

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6857cb58a1b08333bf7514f3bb3f6845