### PR TITLE
Fix iOS text selection and toolbar priorities

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -158,6 +158,16 @@ struct ContentView: View {
 
   @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
+    #if os(iOS)
+    ToolbarItem(placement: .secondaryAction) {
+      Button {
+        settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
+      } label: {
+        Image(systemName: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
+      }
+      .help(settings.localized("toggle_view_tooltip"))
+    }
+    #else
     ToolbarItem {
       Button {
         settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
@@ -166,12 +176,38 @@ struct ContentView: View {
       }
       .help(settings.localized("toggle_view_tooltip"))
     }
+    #endif
+    #if os(iOS)
+    ToolbarItem(placement: .secondaryAction) {
+      Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
+        Image(systemName: settings.projectSortOrder.iconName)
+      }
+      .help(settings.localized("toggle_sort_tooltip"))
+    }
+    #else
     ToolbarItem {
       Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
         Image(systemName: settings.projectSortOrder.iconName)
       }
       .help(settings.localized("toggle_sort_tooltip"))
     }
+    #endif
+    #if os(iOS)
+    ToolbarItemGroup(placement: .secondaryAction) {
+      if selectedProject != nil {
+        Button(action: exportSelectedProject) {
+          Image(systemName: "square.and.arrow.up")
+        }
+        .accessibilityLabel(settings.localized("export"))
+        .help(settings.localized("export_project_tooltip"))
+      }
+      Button(action: importSelectedProject) {
+        Image(systemName: "square.and.arrow.down")
+      }
+      .accessibilityLabel(settings.localized("import"))
+      .help(settings.localized("import_project_tooltip"))
+    }
+    #else
     ToolbarItemGroup {
       if selectedProject != nil {
         Button(action: exportSelectedProject) {
@@ -186,6 +222,16 @@ struct ContentView: View {
       .accessibilityLabel(settings.localized("import"))
       .help(settings.localized("import_project_tooltip"))
     }
+    #endif
+    #if os(iOS)
+    ToolbarItem(placement: .primaryAction) {
+      Button(action: addProject) {
+        Label("add", systemImage: "plus")
+      }
+      .keyboardShortcut("N", modifiers: [.command, .shift])
+      .help(settings.localized("add_project_tooltip"))
+    }
+    #else
     ToolbarItem {
       Button(action: addProject) {
         Label("add", systemImage: "plus")
@@ -193,6 +239,17 @@ struct ContentView: View {
       .keyboardShortcut("N", modifiers: [.command, .shift])
       .help(settings.localized("add_project_tooltip"))
     }
+    #endif
+    #if os(iOS)
+    ToolbarItem(placement: .primaryAction) {
+      Button(action: deleteSelectedProject) {
+        Label("delete", systemImage: "minus")
+      }
+      .keyboardShortcut(.return, modifiers: .command)
+      .disabled(selectedProject == nil)
+      .help(settings.localized("delete_project_tooltip"))
+    }
+    #else
     ToolbarItem {
       Button(action: deleteSelectedProject) {
         Label("delete", systemImage: "minus")
@@ -201,6 +258,7 @@ struct ContentView: View {
       .disabled(selectedProject == nil)
       .help(settings.localized("delete_project_tooltip"))
     }
+    #endif
   }
 
   var body: some View {

--- a/nfprogress/SelectAllIntField.swift
+++ b/nfprogress/SelectAllIntField.swift
@@ -1,0 +1,68 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Numeric text field that focuses automatically and selects its contents when it appears.
+struct SelectAllIntField: View {
+    @Binding var value: Int
+    var placeholder: LocalizedStringKey
+    var focusOnAppear: Bool = false
+
+    @State private var didFocus: Bool = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        TextField(placeholder, value: $value, format: .number)
+            .textFieldStyle(.roundedBorder)
+#if os(iOS)
+            .keyboardType(.numberPad)
+#endif
+            .focused($isFocused)
+            .onAppear {
+                guard focusOnAppear, !didFocus else { return }
+                didFocus = true
+                DispatchQueue.main.async {
+                    isFocused = true
+                }
+            }
+            .onChange(of: isFocused) { focused in
+                if focused {
+                    DispatchQueue.main.async {
+                        selectAll()
+                    }
+                }
+            }
+    }
+
+#if os(iOS)
+    private func selectAll() {
+        guard let controller = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first(where: { $0.isKeyWindow }),
+              let root = controller.rootViewController else { return }
+
+        selectAll(from: root.view)
+    }
+
+    private func selectAll(from view: UIView) {
+        if let textField = view as? UITextField, textField.isFirstResponder {
+            textField.selectedTextRange = textField.textRange(from: textField.beginningOfDocument,
+                                                             to: textField.endOfDocument)
+        } else {
+            for subview in view.subviews {
+                selectAll(from: subview)
+            }
+        }
+    }
+#elseif os(macOS)
+    private func selectAll() {
+        if let editor = NSApp.keyWindow?.firstResponder as? NSTextView {
+            editor.selectAll(nil)
+        } else if let field = NSApp.keyWindow?.firstResponder as? NSTextField {
+            field.currentEditor()?.selectAll(nil)
+        }
+    }
+#else
+    private func selectAll() {}
+#endif
+}
+#endif


### PR DESCRIPTION
## Summary
- ensure text field selection on iOS after focus occurs
- prioritize add/delete project buttons on iOS and hide others under ellipsis

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6857cb58a1b08333bf7514f3bb3f6845