### PR TITLE
Update iPad toolbar layout

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -170,51 +170,46 @@ struct ContentView: View {
   private var toolbarContent: some ToolbarContent {
 #if os(iOS)
     if UIDevice.current.userInterfaceIdiom == .pad {
-      ToolbarItemGroup(placement: .primaryAction) {
-        Button(action: addProject) {
-          Label("add", systemImage: "plus")
-        }
-        .keyboardShortcut("N", modifiers: [.command, .shift])
-        .help(settings.localized("add_project_tooltip"))
+      ToolbarItem(placement: .navigationBarTrailing) {
+        HStack {
+          Button(action: addProject) {
+            Label("add", systemImage: "plus")
+          }
+          .keyboardShortcut("N", modifiers: [.command, .shift])
+          .help(settings.localized("add_project_tooltip"))
 
-        Button(action: deleteSelectedProject) {
-          Label("delete", systemImage: "minus")
-        }
-        .keyboardShortcut(.return, modifiers: .command)
-        .disabled(selectedProject == nil)
-        .help(settings.localized("delete_project_tooltip"))
+          Button(action: deleteSelectedProject) {
+            Label("delete", systemImage: "minus")
+          }
+          .keyboardShortcut(.return, modifiers: .command)
+          .disabled(selectedProject == nil)
+          .help(settings.localized("delete_project_tooltip"))
 
-        if selectedProject == nil {
           Button(action: importSelectedProject) {
             Image(systemName: "square.and.arrow.down")
           }
           .accessibilityLabel(settings.localized("import"))
           .help(settings.localized("import_project_tooltip"))
-        }
-      }
-
-      ToolbarItem(placement: .secondaryAction) {
-        Menu {
-          Button {
-            settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
-          } label: {
-            Label(settings.localized("toggle_view_tooltip"), systemImage: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
-          }
-
-          Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
-            Label(settings.localized("toggle_sort_tooltip"), systemImage: settings.projectSortOrder.iconName)
-          }
 
           if selectedProject != nil {
             Button(action: exportSelectedProject) {
-              Label(settings.localized("export"), systemImage: "square.and.arrow.up")
+              Image(systemName: "square.and.arrow.up")
             }
-            Button(action: importSelectedProject) {
-              Label(settings.localized("import"), systemImage: "square.and.arrow.down")
+            .accessibilityLabel(settings.localized("export"))
+            .help(settings.localized("export_project_tooltip"))
+
+            Button {
+              settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
+            } label: {
+              Image(systemName: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
             }
+            .help(settings.localized("toggle_view_tooltip"))
+
+            Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
+              Image(systemName: settings.projectSortOrder.iconName)
+            }
+            .help(settings.localized("toggle_sort_tooltip"))
           }
-        } label: {
-          Image(systemName: "ellipsis.circle")
         }
       }
     } else {


### PR DESCRIPTION
## Summary
- show all iPad toolbar buttons in a single row
- keep import and export visible when a project is selected
- keep add/delete/import visible when no project is selected

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6858ef2abf208333ab799a123918db1e