### PR TITLE
Fix missing import in iOS menu

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -301,6 +301,9 @@ struct ContentView: View {
             Label(settings.localized("export"), systemImage: "square.and.arrow.up")
           }
         }
+        Button(action: importSelectedProject) {
+          Label(settings.localized("import"), systemImage: "square.and.arrow.down")
+        }
       } label: {
         Image(systemName: "ellipsis.circle")
       }


### PR DESCRIPTION
## Summary
- restore Import button under the ellipsis menu on iOS

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6858f7846554833391139d8052e17cd8