### PR TITLE
Fix menu logic for iPhone and macOS

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -260,9 +260,34 @@ struct ContentView: View {
           .help(settings.localized("delete_project_tooltip"))
         }
       }
+
+      ToolbarItem(placement: .navigationBarTrailing) {
+        Menu {
+          Button {
+            settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
+          } label: {
+            Label(settings.localized("toggle_view_tooltip"), systemImage: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
+          }
+
+          Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
+            Label(settings.localized("toggle_sort_tooltip"), systemImage: settings.projectSortOrder.iconName)
+          }
+
+          if selectedProject != nil {
+            Button(action: exportSelectedProject) {
+              Label(settings.localized("export"), systemImage: "square.and.arrow.up")
+            }
+          }
+          Button(action: importSelectedProject) {
+            Label(settings.localized("import"), systemImage: "square.and.arrow.down")
+          }
+        } label: {
+          Image(systemName: "ellipsis.circle")
+        }
+      }
     }
 #else
-    ToolbarItemGroup(placement: .primaryAction) {
+    ToolbarItemGroup(placement: .automatic) {
       Button(action: addProject) {
         Label("add", systemImage: "plus")
       }
@@ -282,30 +307,25 @@ struct ContentView: View {
       }
       .accessibilityLabel(settings.localized("import"))
       .help(settings.localized("import_project_tooltip"))
-    }
 
-    ToolbarItem {
-      Menu {
+      if selectedProject != nil {
+        Button(action: exportSelectedProject) {
+          Image(systemName: "square.and.arrow.up")
+        }
+        .accessibilityLabel(settings.localized("export"))
+        .help(settings.localized("export_project_tooltip"))
+
         Button {
           settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
         } label: {
-          Label(settings.localized("toggle_view_tooltip"), systemImage: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
+          Image(systemName: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
         }
+        .help(settings.localized("toggle_view_tooltip"))
 
         Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
-          Label(settings.localized("toggle_sort_tooltip"), systemImage: settings.projectSortOrder.iconName)
+          Image(systemName: settings.projectSortOrder.iconName)
         }
-
-        if selectedProject != nil {
-          Button(action: exportSelectedProject) {
-            Label(settings.localized("export"), systemImage: "square.and.arrow.up")
-          }
-        }
-        Button(action: importSelectedProject) {
-          Label(settings.localized("import"), systemImage: "square.and.arrow.down")
-        }
-      } label: {
-        Image(systemName: "ellipsis.circle")
+        .help(settings.localized("toggle_sort_tooltip"))
       }
     }
 #endif


### PR DESCRIPTION
## Summary
- add a trailing ellipsis menu on iPhone so extra controls work
- show macOS toolbar buttons the same way as on iPad

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6858fa1fcb608333b9691147e21a59ef