### PR TITLE
Adjust toolbar menu for import/export

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -261,9 +261,18 @@ struct ContentView: View {
         }
       }
 
-      if selectedProject == nil {
         ToolbarItem(placement: .navigationBarTrailing) {
           Menu {
+            if selectedProject != nil {
+              Button(action: importSelectedProject) {
+                Label(settings.localized("import"), systemImage: "square.and.arrow.down")
+              }
+
+              Button(action: exportSelectedProject) {
+                Label(settings.localized("export"), systemImage: "square.and.arrow.up")
+              }
+            }
+
             Button {
               settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
             } label: {
@@ -277,7 +286,6 @@ struct ContentView: View {
             Image(systemName: "ellipsis.circle")
           }
         }
-      }
     }
 #else
     ToolbarItemGroup(placement: .automatic) {


### PR DESCRIPTION
## Summary
- show import and export items inside the toolbar menu when a project is selected

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6858fef1ebbc83338e88415a8c290eea