### PR TITLE
Add macOS window auto width

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -27,9 +27,22 @@ struct ContentView: View {
   @State private var showDeleteAlert = false
 
   private let circleHeight: CGFloat = layoutStep(10)
+#if os(macOS)
+  /// Minimal window width when no project is selected.
+  private let baseWindowWidth: CGFloat = layoutStep(35)
+  /// Expanded window width to fit all toolbar buttons.
+  private let expandedWindowWidth: CGFloat = layoutStep(48)
+#endif
 #if os(iOS)
   /// Enlarged circle size used when projects are displayed in the main menu.
   private let largeCircleHeight: CGFloat = layoutStep(20)
+#endif
+
+#if os(macOS)
+  /// Current minimum width required for the window.
+  private var minWindowWidth: CGFloat {
+    selectedProject == nil ? baseWindowWidth : expandedWindowWidth
+  }
 #endif
 
   private var sortedProjects: [WritingProject] {
@@ -354,6 +367,7 @@ struct ContentView: View {
     }
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
+    .windowMinWidth(minWindowWidth)
 #endif
   }
 

--- a/nfprogress/WindowMinSizeModifier.swift
+++ b/nfprogress/WindowMinSizeModifier.swift
@@ -1,0 +1,37 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+private struct WindowMinWidthSetter: NSViewRepresentable {
+    var width: CGFloat
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { apply(to: view) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { apply(to: nsView) }
+    }
+
+    private func apply(to view: NSView) {
+        guard let window = view.window else { return }
+        var size = window.contentMinSize
+        size.width = width
+        window.contentMinSize = size
+        if window.frame.width < width {
+            var frame = window.frame
+            frame.size.width = width
+            window.setFrame(frame, display: true)
+        }
+    }
+}
+
+extension View {
+    /// Sets the minimum width for the macOS window containing this view.
+    func windowMinWidth(_ width: CGFloat) -> some View {
+        background(WindowMinWidthSetter(width: width))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- dynamically adjust macOS main window width depending on whether a project is selected
- add `windowMinWidth` helper for macOS windows
- fix dynamic auto width by ensuring the window expands when needed

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685907490918833398e20a8a1152454f