### PR TITLE
Fix macOS main menu width

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -28,6 +28,8 @@ struct ContentView: View {
 
   private let circleHeight: CGFloat = layoutStep(10)
 #if os(macOS)
+  /// Minimal window width when no project is selected.
+  private let baseWindowWidth: CGFloat = layoutStep(35)
   /// Expanded window width to fit all toolbar buttons.
   private let expandedWindowWidth: CGFloat = layoutStep(48)
 #endif
@@ -39,7 +41,7 @@ struct ContentView: View {
 #if os(macOS)
   /// Current minimum width required for the window.
   private var minWindowWidth: CGFloat {
-    selectedProject == nil ? 0 : expandedWindowWidth
+    selectedProject == nil ? baseWindowWidth : expandedWindowWidth
   }
 #endif
 


### PR DESCRIPTION
## Summary
- keep minimal width on macOS when no project is selected
- widen menu when new buttons appear

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6859105784188333976f67d3b1d293cb