### PR TITLE
Fix custom macOS window sizing

### DIFF
--- a/nfprogress/WindowDefaultSizeModifier.swift
+++ b/nfprogress/WindowDefaultSizeModifier.swift
@@ -1,0 +1,40 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+private struct WindowDefaultSizeSetter: NSViewRepresentable {
+    var width: CGFloat
+    var height: CGFloat
+
+    class Coordinator {
+        var applied = false
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { apply(to: view, coordinator: context.coordinator) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { apply(to: nsView, coordinator: context.coordinator) }
+    }
+
+    private func apply(to view: NSView, coordinator: Coordinator) {
+        guard let window = view.window, !coordinator.applied else { return }
+        coordinator.applied = true
+        var frame = window.frame
+        frame.size = NSSize(width: width, height: height)
+        window.setFrame(frame, display: true)
+    }
+}
+
+extension View {
+    /// Sets the default size for the macOS window containing this view.
+    func windowDefaultSize(width: CGFloat, height: CGFloat) -> some View {
+        background(WindowDefaultSizeSetter(width: width, height: height))
+    }
+}
+#endif

--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -48,9 +48,9 @@ extension nfprogressApp {
                 .environment(\.locale, settings.locale)
 #if os(macOS)
                 .windowTitle(settings.localized("new_project"))
+                .windowDefaultSize(width: layoutStep(35), height: layoutStep(20))
 #endif
         }
-        .defaultSize(width: layoutStep(35), height: layoutStep(20))
         .modelContainer(DataController.shared)
 
         WindowGroup(id: "addStage", for: AddStageRequest.self) { binding in
@@ -62,10 +62,10 @@ extension nfprogressApp {
                     .environment(\.locale, settings.locale)
 #if os(macOS)
                     .windowTitle(settings.localized("new_stage"))
+                    .windowDefaultSize(width: layoutStep(35), height: layoutStep(20))
 #endif
             }
         }
-        .defaultSize(width: layoutStep(35), height: layoutStep(20))
         .modelContainer(DataController.shared)
 
         WindowGroup(id: "addEntry", for: AddEntryRequest.self) { binding in
@@ -79,6 +79,7 @@ extension nfprogressApp {
                         .environment(\.locale, settings.locale)
 #if os(macOS)
                         .windowTitle(settings.localized("new_entry"))
+                        .windowDefaultSize(width: layoutStep(35), height: layoutStep(20))
 #endif
                 } else {
                     AddEntryView(project: project)
@@ -86,11 +87,11 @@ extension nfprogressApp {
                         .environment(\.locale, settings.locale)
 #if os(macOS)
                         .windowTitle(settings.localized("new_entry"))
+                        .windowDefaultSize(width: layoutStep(35), height: layoutStep(20))
 #endif
                 }
             }
         }
-        .defaultSize(width: layoutStep(35), height: layoutStep(20))
         .modelContainer(DataController.shared)
 
         WindowGroup(id: "editEntry", for: EditEntryRequest.self) { binding in
@@ -103,10 +104,10 @@ extension nfprogressApp {
                     .environment(\.locale, settings.locale)
 #if os(macOS)
                     .windowTitle("NFProgress")
+                    .windowDefaultSize(width: layoutStep(40), height: layoutStep(25))
 #endif
             }
         }
-        .defaultSize(width: layoutStep(40), height: layoutStep(25))
         .modelContainer(DataController.shared)
     }
 }

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -29,7 +29,7 @@ struct nfprogressApp: App {
                 .environment(\.locale, settings.locale)
 #if os(macOS)
                 .windowTitle("NFProgress")
-                .defaultSize(width: layoutStep(48), height: layoutStep(30))
+                .windowDefaultSize(width: layoutStep(48), height: layoutStep(30))
 #endif
         }
         .modelContainer(DataController.shared)


### PR DESCRIPTION
## Summary
- move `windowDefaultSize` modifier inside each macOS window view
- keep `navigationDestination` attached to `NavigationStack`/`NavigationSplitView`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685915c8e9b8833390560be9f61b21fb