### PR TITLE
Fix initial macOS window size

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -28,22 +28,14 @@ struct ContentView: View {
 
   private let circleHeight: CGFloat = layoutStep(10)
 #if os(macOS)
-  /// Minimal window width when no project is selected.
-  private let baseWindowWidth: CGFloat = layoutStep(35)
-  /// Expanded window width to fit all toolbar buttons.
-  private let expandedWindowWidth: CGFloat = layoutStep(48)
+  /// Minimum width required for the main window.
+  private let minWindowWidth: CGFloat = layoutStep(48)
 #endif
 #if os(iOS)
   /// Enlarged circle size used when projects are displayed in the main menu.
   private let largeCircleHeight: CGFloat = layoutStep(20)
 #endif
 
-#if os(macOS)
-  /// Current minimum width required for the window.
-  private var minWindowWidth: CGFloat {
-    selectedProject == nil ? baseWindowWidth : expandedWindowWidth
-  }
-#endif
 
   private var sortedProjects: [WritingProject] {
     switch settings.projectSortOrder {
@@ -368,8 +360,6 @@ struct ContentView: View {
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)
-    .onAppear { updateWindowWidth() }
-    .onChange(of: selectedProject) { _ in updateWindowWidth() }
 #endif
   }
 
@@ -430,20 +420,6 @@ struct ContentView: View {
     }
   }
 
-  /// Updates the current window width according to ``minWindowWidth``.
-  private func updateWindowWidth() {
-    DispatchQueue.main.async {
-      guard let window = NSApp.keyWindow ?? NSApp.windows.first else { return }
-      var size = window.contentMinSize
-      size.width = minWindowWidth
-      window.contentMinSize = size
-      if window.frame.width < minWindowWidth {
-        var frame = window.frame
-        frame.size.width = minWindowWidth
-        window.setFrame(frame, display: true)
-      }
-    }
-  }
 #endif
 
   // MARK: - Экспорт


### PR DESCRIPTION
## Summary
- keep macOS window width constant at 48 layout steps
- remove runtime adjustments that shrank/expanded the window

## Testing
- `swift test -v`
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_6859196aedd48333a4093aaca5e2ff1c