### PR TITLE
Fix ambiguous navigationDestination closures

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -76,7 +76,7 @@ struct ContentView: View {
               .foregroundColor(.gray)
           }
         })
-        .navigationDestination(for: WritingProject.self) { project in
+        .navigationDestination(for: WritingProject.self) { (project: WritingProject) in
           ProjectDetailView(project: project)
         }
       } else {
@@ -146,7 +146,7 @@ struct ContentView: View {
     .navigationSplitViewColumnWidth(405)
 #endif
     )
-    .navigationDestination(for: WritingProject.self) { project in
+    .navigationDestination(for: WritingProject.self) { (project: WritingProject) in
       ProjectDetailView(project: project)
     }
 #endif


### PR DESCRIPTION
## Summary
- explicitly type closures passed to `navigationDestination` to avoid type inference issues

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6859200872208333bac3b0ae451b041b