### PR TITLE
Fix ambiguous navigation destination type

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -76,7 +76,7 @@ struct ContentView: View {
               .foregroundColor(.gray)
           }
         })
-        .navigationDestination(for: WritingProject.self, destination: { project in
+        .navigationDestination(for: WritingProject.self, destination: { (project: WritingProject) in
           ProjectDetailView(project: project)
         })
       } else {
@@ -146,7 +146,7 @@ struct ContentView: View {
     .navigationSplitViewColumnWidth(405)
 #endif
     )
-    .navigationDestination(for: WritingProject.self, destination: { project in
+    .navigationDestination(for: WritingProject.self, destination: { (project: WritingProject) in
       ProjectDetailView(project: project)
     })
 #endif


### PR DESCRIPTION
## Summary
- specify `WritingProject` parameter type in `navigationDestination`

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685928bee6c88333adde5b0189a658d5