### PR TITLE
Fix ambiguous expression in ContentView

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -131,9 +131,6 @@ struct ContentView: View {
       .listStyle(.plain)
       .navigationTitle("my_texts")
       .toolbar { toolbarContent }
-#if os(macOS)
-      .navigationSplitViewColumnWidth(405)
-#endif
     }, detail: {
       if let project = selectedProject {
         ProjectDetailView(project: project)
@@ -141,11 +138,10 @@ struct ContentView: View {
         Text("select_project")
           .foregroundColor(.gray)
       }
-    }
+    })
 #if os(macOS)
     .navigationSplitViewColumnWidth(405)
 #endif
-    )
     .navigationDestination(for: WritingProject.self) { project in
       ProjectDetailView(project: project)
     }


### PR DESCRIPTION
## Summary
- clean up `NavigationSplitView` modifier chaining to compile on macOS

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685932aa947083338f51ade2e9ed7d01