### PR TITLE
Fix share image compile errors

### DIFF
--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -56,6 +56,7 @@ private struct ProgressShareView: View {
     }
 }
 
+@MainActor
 func progressShareImage(for project: WritingProject) -> OSImage? {
     let renderer = ImageRenderer(content: ProgressShareView(project: project))
 #if canImport(UIKit)
@@ -71,7 +72,7 @@ struct ShareableProgressImage: Transferable {
     var image: OSImage
 
     static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation(exportedContentType: .png) { item in
+        DataRepresentation(contentType: .png) { item in
 #if canImport(UIKit)
             item.image.pngData() ?? Data()
 #else


### PR DESCRIPTION
## Summary
- ensure progress image creation runs on the main actor
- use the current `contentType` parameter when exporting the image

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_685939b472a483339d10277bf9add53f