### PR TITLE
Fix share image concurrency

### DIFF
--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -58,7 +58,10 @@ private struct ProgressShareView: View {
 
 @MainActor
 func progressShareImage(for project: WritingProject) -> OSImage? {
-    let renderer = ImageRenderer(content: ProgressShareView(project: project))
+    // Break the rendering steps into smaller expressions to
+    // help the compiler with type inference.
+    let view = ProgressShareView(project: project)
+    let renderer = ImageRenderer(content: view)
 #if canImport(UIKit)
     renderer.scale = UIScreen.main.scale
     return renderer.uiImage

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -58,7 +58,7 @@ struct ProjectDetailView: View {
     }
 
     /// Image used for sharing the current progress circle.
-    private var shareItem: ShareableProgressImage? {
+    @MainActor private var shareItem: ShareableProgressImage? {
         guard let image = progressShareImage(for: project) else { return nil }
         return ShareableProgressImage(image: image)
     }


### PR DESCRIPTION
## Summary
- ensure share image rendering occurs on the main actor
- simplify ImageRenderer creation to avoid type inference issues
- mark ProjectDetailView shareItem as MainActor

## Testing
- `swift build --product nfprogress`

------
https://chatgpt.com/codex/tasks/task_e_68593ab0d2b88333b641cb327a65411e