### PR TITLE
Fix share image concurrency

### DIFF
--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -1,5 +1,6 @@
 #if canImport(SwiftUI)
 import SwiftUI
+import UniformTypeIdentifiers
 
 #if canImport(UIKit)
 import UIKit


### PR DESCRIPTION
## Summary
- import UniformTypeIdentifiers explicitly for share image export

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68593c1ed8908333b86e8c1ee4f7dcdc