### PR TITLE
Исправление предпросмотра и сохранение настроек экспорта

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -3,6 +3,13 @@ import Foundation
 import SwiftUI
 #endif
 
+// Default values for share preview settings
+let defaultShareCircleSize: Double = 175
+let defaultShareRingWidth: Double = 24
+let defaultSharePercentSize: Double = 45
+let defaultShareTitleSize: Double = 56
+let defaultShareSpacing: Double = 16
+
 enum AppLanguage: String, CaseIterable, Identifiable {
     case system
     case en
@@ -80,6 +87,23 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(projectSortOrder.rawValue, forKey: "projectSortOrder") }
     }
 
+    // Last used export parameters
+    @Published var lastShareCircleSize: Double {
+        didSet { defaults.set(lastShareCircleSize, forKey: "lastShareCircleSize") }
+    }
+    @Published var lastShareRingWidth: Double {
+        didSet { defaults.set(lastShareRingWidth, forKey: "lastShareRingWidth") }
+    }
+    @Published var lastSharePercentSize: Double {
+        didSet { defaults.set(lastSharePercentSize, forKey: "lastSharePercentSize") }
+    }
+    @Published var lastShareTitleSize: Double {
+        didSet { defaults.set(lastShareTitleSize, forKey: "lastShareTitleSize") }
+    }
+    @Published var lastShareSpacing: Double {
+        didSet { defaults.set(lastShareSpacing, forKey: "lastShareSpacing") }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -92,6 +116,16 @@ final class AppSettings: ObservableObject {
         projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
         let sortRaw = defaults.string(forKey: "projectSortOrder") ?? ProjectSortOrder.title.rawValue
         projectSortOrder = ProjectSortOrder(rawValue: sortRaw) ?? .title
+        let c = defaults.double(forKey: "lastShareCircleSize")
+        lastShareCircleSize = c == 0 ? defaultShareCircleSize : c
+        let r = defaults.double(forKey: "lastShareRingWidth")
+        lastShareRingWidth = r == 0 ? defaultShareRingWidth : r
+        let p = defaults.double(forKey: "lastSharePercentSize")
+        lastSharePercentSize = p == 0 ? defaultSharePercentSize : p
+        let t = defaults.double(forKey: "lastShareTitleSize")
+        lastShareTitleSize = t == 0 ? defaultShareTitleSize : t
+        let s = defaults.double(forKey: "lastShareSpacing")
+        lastShareSpacing = s == 0 ? defaultShareSpacing : s
     }
 }
 #else
@@ -138,6 +172,23 @@ final class AppSettings {
         didSet { defaults.set(projectSortOrder.rawValue, forKey: "projectSortOrder") }
     }
 
+    // Last used export parameters
+    var lastShareCircleSize: Double {
+        didSet { defaults.set(lastShareCircleSize, forKey: "lastShareCircleSize") }
+    }
+    var lastShareRingWidth: Double {
+        didSet { defaults.set(lastShareRingWidth, forKey: "lastShareRingWidth") }
+    }
+    var lastSharePercentSize: Double {
+        didSet { defaults.set(lastSharePercentSize, forKey: "lastSharePercentSize") }
+    }
+    var lastShareTitleSize: Double {
+        didSet { defaults.set(lastShareTitleSize, forKey: "lastShareTitleSize") }
+    }
+    var lastShareSpacing: Double {
+        didSet { defaults.set(lastShareSpacing, forKey: "lastShareSpacing") }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -150,6 +201,16 @@ final class AppSettings {
         projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
         let sortRaw = defaults.string(forKey: "projectSortOrder") ?? ProjectSortOrder.title.rawValue
         projectSortOrder = ProjectSortOrder(rawValue: sortRaw) ?? .title
+        let c = defaults.double(forKey: "lastShareCircleSize")
+        lastShareCircleSize = c == 0 ? defaultShareCircleSize : c
+        let r = defaults.double(forKey: "lastShareRingWidth")
+        lastShareRingWidth = r == 0 ? defaultShareRingWidth : r
+        let p = defaults.double(forKey: "lastSharePercentSize")
+        lastSharePercentSize = p == 0 ? defaultSharePercentSize : p
+        let t = defaults.double(forKey: "lastShareTitleSize")
+        lastShareTitleSize = t == 0 ? defaultShareTitleSize : t
+        let s = defaults.double(forKey: "lastShareSpacing")
+        lastShareSpacing = s == 0 ? defaultShareSpacing : s
     }
 }
 #endif

--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -1,0 +1,76 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct ProgressSharePreview: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var settings: AppSettings
+    var project: WritingProject
+    var shareAction: (_ circleSize: CGFloat, _ ringWidth: CGFloat, _ percentFont: CGFloat, _ titleFont: CGFloat, _ spacing: CGFloat) -> Void
+
+    @State private var circleSize: CGFloat = CGFloat(defaultShareCircleSize)
+    @State private var ringWidth: CGFloat = CGFloat(defaultShareRingWidth)
+    @State private var percentSize: CGFloat = CGFloat(defaultSharePercentSize)
+    @State private var titleSize: CGFloat = CGFloat(defaultShareTitleSize)
+    @State private var spacing: CGFloat = CGFloat(defaultShareSpacing)
+    @State private var initialized = false
+
+    var body: some View {
+        VStack(spacing: scaledSpacing(2)) {
+            Spacer()
+            ProgressShareView(project: project,
+                               circleSize: circleSize,
+                               ringWidth: ringWidth,
+                               percentFontSize: percentSize,
+                               titleFontSize: titleSize,
+                               titleSpacing: spacing)
+            VStack {
+                HStack {
+                    Text(settings.localized("share_preview_circle_size"))
+                    Slider(value: $circleSize, in: 100...shareImageSize)
+                }
+                HStack {
+                    Text(settings.localized("share_preview_ring_width"))
+                    Slider(value: $ringWidth, in: 1...60)
+                }
+                HStack {
+                    Text(settings.localized("share_preview_percent_size"))
+                    Slider(value: $percentSize, in: 10...120)
+                }
+                HStack {
+                    Text(settings.localized("share_preview_title_size"))
+                    Slider(value: $titleSize, in: 20...100)
+                }
+                HStack {
+                    Text(settings.localized("share_preview_spacing"))
+                    Slider(value: $spacing, in: 0...layoutStep(20))
+                }
+            }
+            Spacer()
+            HStack(spacing: scaledSpacing(2)) {
+                Button("cancel", role: .cancel) { dismiss() }
+                Button(settings.localized("export")) {
+                    dismiss()
+                    DispatchQueue.main.async {
+                        shareAction(circleSize, ringWidth, percentSize, titleSize, spacing)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .scaledPadding()
+        .frame(minWidth: shareImageSize + layoutStep(4),
+               minHeight: shareImageSize + layoutStep(20))
+        .onAppear {
+            if !initialized {
+                circleSize = CGFloat(settings.lastShareCircleSize)
+                ringWidth = CGFloat(settings.lastShareRingWidth)
+                percentSize = CGFloat(settings.lastSharePercentSize)
+                titleSize = CGFloat(settings.lastShareTitleSize)
+                spacing = CGFloat(settings.lastShareSpacing)
+                initialized = true
+            }
+        }
+    }
+}
+#endif

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -33,6 +33,7 @@ struct ProjectDetailView: View {
     @State private var showingShareSheet = false
 #endif
     @State private var shareURL: URL?
+    @State private var showingSharePreview = false
 
     /// Base spacing for history and stages sections.
     private let viewSpacing: CGFloat = scaledSpacing(2)
@@ -291,14 +292,28 @@ struct ProjectDetailView: View {
     }
 
     private func shareToolbarButton() -> some View {
-        Button(action: shareProgress) {
+        Button(action: { showingSharePreview = true }) {
             Image(systemName: "square.and.arrow.up")
         }
         .help(settings.localized("share_progress_tooltip"))
     }
 
-    private func shareProgress() {
-        guard let url = progressShareURL(for: project) else { return }
+    private func shareProgress(circleSize: CGFloat,
+                               ringWidth: CGFloat,
+                               percentSize: CGFloat,
+                               titleSize: CGFloat,
+                               spacing: CGFloat) {
+        guard let url = progressShareURL(for: project,
+                                         circleSize: circleSize,
+                                         ringWidth: ringWidth,
+                                         percentFontSize: percentSize,
+                                         titleFontSize: titleSize,
+                                         titleSpacing: spacing) else { return }
+        settings.lastShareCircleSize = Double(circleSize)
+        settings.lastShareRingWidth = Double(ringWidth)
+        settings.lastSharePercentSize = Double(percentSize)
+        settings.lastShareTitleSize = Double(titleSize)
+        settings.lastShareSpacing = Double(spacing)
         shareURL = url
 #if os(iOS)
         showingShareSheet = true
@@ -523,6 +538,16 @@ struct ProjectDetailView: View {
             ToolbarItem(placement: .primaryAction) {
                 shareToolbarButton()
             }
+        }
+        .sheet(isPresented: $showingSharePreview) {
+            ProgressSharePreview(project: project) { cSize, rWidth, pSize, tSize, space in
+                shareProgress(circleSize: cSize,
+                              ringWidth: rWidth,
+                              percentSize: pSize,
+                              titleSize: tSize,
+                              spacing: space)
+            }
+            .environmentObject(settings)
         }
 #if os(iOS)
         .sheet(isPresented: $showingShareSheet, onDismiss: {

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -75,3 +75,8 @@
 "import_project_tooltip" = "Import project";
 "toggle_sort_tooltip" = "Change sort order";
 "share_progress_tooltip" = "Share progress";
+"share_preview_circle_size" = "Circle size";
+"share_preview_ring_width" = "Ring width";
+"share_preview_percent_size" = "Percent size";
+"share_preview_title_size" = "Title size";
+"share_preview_spacing" = "Title spacing";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -75,3 +75,8 @@
 "import_project_tooltip" = "Импортировать проект";
 "toggle_sort_tooltip" = "Изменить сортировку";
 "share_progress_tooltip" = "Поделиться прогрессом";
+"share_preview_circle_size" = "Размер диаграммы";
+"share_preview_ring_width" = "Толщина круга";
+"share_preview_percent_size" = "Размер процентов";
+"share_preview_title_size" = "Размер названия";
+"share_preview_spacing" = "Расстояние";


### PR DESCRIPTION
## Изменения
- переработан `ProgressShareView`: диаграмма и заголовок центрируются, добавлен параметр `titleSpacing`
- предпросмотр (`ProgressSharePreview`) получил настройку расстояния, загружает и сохраняет параметры через `AppSettings`
- `ProjectDetailView` передает новые параметры и запоминает их после экспорта
- в `AppSettings` сохранены последние значения настроек экспорта
- добавлены строки локализации для новой настройки

## Тестирование
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68595a7e774c833387ce43a84f75976c