### PR TITLE
Адаптивный предпросмотр экспорта

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -3,6 +3,14 @@ import Foundation
 import SwiftUI
 #endif
 
+// Default values for share preview settings
+let defaultShareCircleSize: Double = 175
+let defaultShareRingWidth: Double = 24
+let defaultSharePercentSize: Double = 45
+let defaultShareTitleSize: Double = 56
+let defaultShareSpacing: Double = 16
+
+
 enum AppLanguage: String, CaseIterable, Identifiable {
     case system
     case en
@@ -80,6 +88,23 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(projectSortOrder.rawValue, forKey: "projectSortOrder") }
     }
 
+    // Last used export parameters
+    @Published var lastShareCircleSize: Double {
+        didSet { defaults.set(lastShareCircleSize, forKey: "lastShareCircleSize") }
+    }
+    @Published var lastShareRingWidth: Double {
+        didSet { defaults.set(lastShareRingWidth, forKey: "lastShareRingWidth") }
+    }
+    @Published var lastSharePercentSize: Double {
+        didSet { defaults.set(lastSharePercentSize, forKey: "lastSharePercentSize") }
+    }
+    @Published var lastShareTitleSize: Double {
+        didSet { defaults.set(lastShareTitleSize, forKey: "lastShareTitleSize") }
+    }
+    @Published var lastShareSpacing: Double {
+        didSet { defaults.set(lastShareSpacing, forKey: "lastShareSpacing") }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -92,6 +117,16 @@ final class AppSettings: ObservableObject {
         projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
         let sortRaw = defaults.string(forKey: "projectSortOrder") ?? ProjectSortOrder.title.rawValue
         projectSortOrder = ProjectSortOrder(rawValue: sortRaw) ?? .title
+        let c = defaults.double(forKey: "lastShareCircleSize")
+        lastShareCircleSize = c == 0 ? defaultShareCircleSize : c
+        let r = defaults.double(forKey: "lastShareRingWidth")
+        lastShareRingWidth = r == 0 ? defaultShareRingWidth : r
+        let p = defaults.double(forKey: "lastSharePercentSize")
+        lastSharePercentSize = p == 0 ? defaultSharePercentSize : p
+        let t = defaults.double(forKey: "lastShareTitleSize")
+        lastShareTitleSize = t == 0 ? defaultShareTitleSize : t
+        let s = defaults.double(forKey: "lastShareSpacing")
+        lastShareSpacing = s == 0 ? defaultShareSpacing : s
     }
 }
 #else
@@ -138,6 +173,23 @@ final class AppSettings {
         didSet { defaults.set(projectSortOrder.rawValue, forKey: "projectSortOrder") }
     }
 
+    // Last used export parameters
+    var lastShareCircleSize: Double {
+        didSet { defaults.set(lastShareCircleSize, forKey: "lastShareCircleSize") }
+    }
+    var lastShareRingWidth: Double {
+        didSet { defaults.set(lastShareRingWidth, forKey: "lastShareRingWidth") }
+    }
+    var lastSharePercentSize: Double {
+        didSet { defaults.set(lastSharePercentSize, forKey: "lastSharePercentSize") }
+    }
+    var lastShareTitleSize: Double {
+        didSet { defaults.set(lastShareTitleSize, forKey: "lastShareTitleSize") }
+    }
+    var lastShareSpacing: Double {
+        didSet { defaults.set(lastShareSpacing, forKey: "lastShareSpacing") }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -150,6 +202,16 @@ final class AppSettings {
         projectListStyle = ProjectListStyle(rawValue: styleRaw) ?? .detailed
         let sortRaw = defaults.string(forKey: "projectSortOrder") ?? ProjectSortOrder.title.rawValue
         projectSortOrder = ProjectSortOrder(rawValue: sortRaw) ?? .title
+        let c = defaults.double(forKey: "lastShareCircleSize")
+        lastShareCircleSize = c == 0 ? defaultShareCircleSize : c
+        let r = defaults.double(forKey: "lastShareRingWidth")
+        lastShareRingWidth = r == 0 ? defaultShareRingWidth : r
+        let p = defaults.double(forKey: "lastSharePercentSize")
+        lastSharePercentSize = p == 0 ? defaultSharePercentSize : p
+        let t = defaults.double(forKey: "lastShareTitleSize")
+        lastShareTitleSize = t == 0 ? defaultShareTitleSize : t
+        let s = defaults.double(forKey: "lastShareSpacing")
+        lastShareSpacing = s == 0 ? defaultShareSpacing : s
     }
 }
 #endif

--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -10,12 +10,15 @@ public typealias OSImage = NSImage
 #endif
 
 /// Size of the exported progress image in points.
-private let shareImageSize: CGFloat = 500
+let shareImageSize: CGFloat = 500
+
 
 /// Snapshot of ``ProgressCircleView`` without animations.
 private struct ProgressCircleSnapshotView: View {
     var project: WritingProject
-    var style: ProgressCircleStyle = .large
+    var size: CGFloat
+    var ringWidth: CGFloat
+    var percentFontSize: CGFloat
 
     private var progress: Double {
         guard project.goal > 0 else { return 0 }
@@ -23,9 +26,7 @@ private struct ProgressCircleSnapshotView: View {
         return min(max(value, 0), 1)
     }
 
-    private var ringWidth: CGFloat { (style == .large ? layoutStep(3) : layoutStep(2)) * 2 }
     private var color: Color { .interpolate(from: .red, to: .green, fraction: progress) }
-    private var fontToken: FontToken { style == .large ? .progressValueLarge : .progressValue }
 
     var body: some View {
         ZStack {
@@ -36,24 +37,38 @@ private struct ProgressCircleSnapshotView: View {
                 .rotationEffect(.degrees(-90))
             let percent = Int(ceil(progress * 100))
             Text("\(percent)%")
-                .font(.system(size: calcFontSize(token: fontToken) * 3))
+                .font(.system(size: percentFontSize))
                 .monospacedDigit()
                 .bold()
                 .foregroundColor(color)
         }
+        .frame(width: size, height: size)
     }
 }
 
-private struct ProgressShareView: View {
+struct ProgressShareView: View {
     var project: WritingProject
+    var circleSize: CGFloat = CGFloat(defaultShareCircleSize)
+    var ringWidth: CGFloat = CGFloat(defaultShareRingWidth)
+    var percentFontSize: CGFloat = CGFloat(defaultSharePercentSize)
+    var titleFontSize: CGFloat = CGFloat(defaultShareTitleSize)
+    var titleSpacing: CGFloat = CGFloat(defaultShareSpacing)
 
     var body: some View {
-        VStack(spacing: scaledSpacing(2)) {
-            ProgressCircleSnapshotView(project: project, style: .large)
-                .frame(width: shareImageSize * 0.7, height: shareImageSize * 0.7)
+        VStack(spacing: 0) {
+            Spacer()
+            ProgressCircleSnapshotView(project: project,
+                                       size: circleSize,
+                                       ringWidth: ringWidth,
+                                       percentFontSize: percentFontSize)
+            Spacer().frame(height: titleSpacing)
             Text(project.title)
-                .font(.title.bold())
+                .font(.system(size: titleFontSize, weight: .bold))
                 .multilineTextAlignment(.center)
+                .foregroundColor(.black)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
         }
         .frame(width: shareImageSize, height: shareImageSize)
         .background(Color.white)
@@ -61,8 +76,18 @@ private struct ProgressShareView: View {
 }
 
 @MainActor
-func progressShareImage(for project: WritingProject) -> OSImage? {
-    let view = ProgressShareView(project: project)
+func progressShareImage(for project: WritingProject,
+                        circleSize: CGFloat = CGFloat(defaultShareCircleSize),
+                        ringWidth: CGFloat = CGFloat(defaultShareRingWidth),
+                        percentFontSize: CGFloat = CGFloat(defaultSharePercentSize),
+                        titleFontSize: CGFloat = CGFloat(defaultShareTitleSize),
+                        titleSpacing: CGFloat = CGFloat(defaultShareSpacing)) -> OSImage? {
+    let view = ProgressShareView(project: project,
+                                 circleSize: circleSize,
+                                 ringWidth: ringWidth,
+                                 percentFontSize: percentFontSize,
+                                 titleFontSize: titleFontSize,
+                                 titleSpacing: titleSpacing)
     let renderer = ImageRenderer(content: view)
 #if swift(>=5.9)
     renderer.proposedSize = ProposedViewSize(width: shareImageSize, height: shareImageSize)
@@ -80,8 +105,18 @@ func progressShareImage(for project: WritingProject) -> OSImage? {
 
 
 @MainActor
-func progressShareURL(for project: WritingProject) -> URL? {
-    guard let image = progressShareImage(for: project) else { return nil }
+func progressShareURL(for project: WritingProject,
+                      circleSize: CGFloat = CGFloat(defaultShareCircleSize),
+                      ringWidth: CGFloat = CGFloat(defaultShareRingWidth),
+                      percentFontSize: CGFloat = CGFloat(defaultSharePercentSize),
+                      titleFontSize: CGFloat = CGFloat(defaultShareTitleSize),
+                      titleSpacing: CGFloat = CGFloat(defaultShareSpacing)) -> URL? {
+    guard let image = progressShareImage(for: project,
+                                         circleSize: circleSize,
+                                         ringWidth: ringWidth,
+                                         percentFontSize: percentFontSize,
+                                         titleFontSize: titleFontSize,
+                                         titleSpacing: titleSpacing) else { return nil }
 #if canImport(UIKit)
     guard let data = image.pngData() else { return nil }
 #else

--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -1,0 +1,188 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+
+struct ProgressSharePreview: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var settings: AppSettings
+    var project: WritingProject
+
+    // Values stored as percentages of defaults (1...100)
+    @State private var circlePercent: Int = 100
+    @State private var ringPercent: Int = 100
+    @State private var percentFontPercent: Int = 100
+    @State private var titleFontPercent: Int = 100
+    @State private var spacingPercent: Int = 100
+    @State private var initialized = false
+#if os(iOS)
+    @State private var shareURL: URL?
+    @State private var showingShareSheet = false
+    @State private var showingFullImage = false
+#endif
+#if os(iOS)
+    @State private var containerSize: CGSize = .zero
+#endif
+
+    private var circleSize: CGFloat {
+        CGFloat(circlePercent) / 100 * CGFloat(defaultShareCircleSize)
+    }
+    private var ringWidth: CGFloat {
+        CGFloat(ringPercent) / 100 * CGFloat(defaultShareRingWidth)
+    }
+    private var percentSize: CGFloat {
+        CGFloat(percentFontPercent) / 100 * CGFloat(defaultSharePercentSize)
+    }
+    private var titleSize: CGFloat {
+        CGFloat(titleFontPercent) / 100 * CGFloat(defaultShareTitleSize)
+    }
+    private var spacing: CGFloat {
+        CGFloat(spacingPercent) / 100 * CGFloat(defaultShareSpacing)
+    }
+
+    private var orientationScale: CGFloat {
+#if os(iOS)
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            return showingFullImage ? 1 : 0.5
+        } else {
+            return containerSize.width > containerSize.height ? 0.75 : 1
+        }
+#else
+        return 1
+#endif
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            VStack(spacing: scaledSpacing(1.5)) {
+                Spacer()
+                ProgressShareView(project: project,
+                                   circleSize: circleSize,
+                                   ringWidth: ringWidth,
+                                   percentFontSize: percentSize,
+                                   titleFontSize: titleSize,
+                                   titleSpacing: spacing)
+                    .scaleEffect(orientationScale)
+                    .onTapGesture {
+#if os(iOS)
+                        if orientationScale < 1 { showingFullImage = true }
+#endif
+                    }
+                VStack(spacing: scaledSpacing(0.5)) {
+                    pickerRow(title: settings.localized("share_preview_circle_size"), value: $circlePercent)
+                    pickerRow(title: settings.localized("share_preview_ring_width"), value: $ringPercent)
+                    pickerRow(title: settings.localized("share_preview_percent_size"), value: $percentFontPercent)
+                    pickerRow(title: settings.localized("share_preview_title_size"), value: $titleFontPercent)
+                    pickerRow(title: settings.localized("share_preview_spacing"), value: $spacingPercent)
+                }
+                Spacer()
+            }
+            .onChange(of: geo.size) { newValue in
+#if os(iOS)
+                containerSize = newValue
+#endif
+            }
+        }
+        .scaledPadding()
+        #if os(macOS)
+        .frame(width: 560, height: 730)
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) { bottomControls }
+        }
+        #else
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaInset(edge: .bottom) { bottomControls }
+        #endif
+        .onAppear {
+            if !initialized {
+                circlePercent = max(1, min(100, Int((settings.lastShareCircleSize / defaultShareCircleSize * 100).rounded())))
+                ringPercent = max(1, min(100, Int((settings.lastShareRingWidth / defaultShareRingWidth * 100).rounded())))
+                percentFontPercent = max(1, min(100, Int((settings.lastSharePercentSize / defaultSharePercentSize * 100).rounded())))
+                titleFontPercent = max(1, min(100, Int((settings.lastShareTitleSize / defaultShareTitleSize * 100).rounded())))
+                spacingPercent = max(1, min(100, Int((settings.lastShareSpacing / defaultShareSpacing * 100).rounded())))
+                initialized = true
+            }
+        }
+#if os(iOS)
+        .sheet(isPresented: $showingShareSheet, onDismiss: {
+            if let url = shareURL { try? FileManager.default.removeItem(at: url) }
+            shareURL = nil
+            dismiss()
+        }) {
+            if let url = shareURL {
+                ShareSheet(items: [url])
+            }
+        }
+        .fullScreenCover(isPresented: $showingFullImage) {
+            VStack {
+                HStack {
+                    Button(settings.localized("cancel")) { showingFullImage = false }
+                        .padding()
+                    Spacer()
+                }
+                ProgressShareView(project: project,
+                                   circleSize: circleSize,
+                                   ringWidth: ringWidth,
+                                   percentFontSize: percentSize,
+                                   titleFontSize: titleSize,
+                                   titleSpacing: spacing)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.white)
+        }
+#endif
+    }
+
+    private func shareProgress() {
+        guard let url = progressShareURL(for: project,
+                                         circleSize: circleSize,
+                                         ringWidth: ringWidth,
+                                         percentFontSize: percentSize,
+                                         titleFontSize: titleSize,
+                                         titleSpacing: spacing) else { return }
+        settings.lastShareCircleSize = Double(circleSize)
+        settings.lastShareRingWidth = Double(ringWidth)
+        settings.lastSharePercentSize = Double(percentSize)
+        settings.lastShareTitleSize = Double(titleSize)
+        settings.lastShareSpacing = Double(spacing)
+#if os(iOS)
+        shareURL = url
+        showingShareSheet = true
+#else
+        let picker = NSSharingServicePicker(items: [url])
+        if let window = NSApp.keyWindow ?? NSApp.windows.first {
+            picker.show(relativeTo: .zero, of: window.contentView!, preferredEdge: .minY)
+        }
+        dismiss()
+#endif
+    }
+
+    @ViewBuilder
+    private func pickerRow(title: String, value: Binding<Int>) -> some View {
+        HStack {
+            Text(title)
+                .font(.footnote)
+            Picker("", selection: value) {
+                ForEach(1..<101) { num in
+                    Text("\(num)").tag(num)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+        }
+    }
+
+    @ViewBuilder
+    private var bottomControls: some View {
+        HStack {
+            Button(settings.localized("cancel"), role: .cancel) { dismiss() }
+            Spacer()
+            Button(settings.localized("share")) { shareProgress() }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+        }
+        .scaledPadding()
+    }
+}
+#endif

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -30,9 +30,8 @@ struct ProjectDetailView: View {
     @State private var isEditingDeadline = false
     @FocusState private var focusedField: Field?
 #if os(iOS)
-    @State private var showingShareSheet = false
+    @State private var showingSharePreview = false
 #endif
-    @State private var shareURL: URL?
 
     /// Base spacing for history and stages sections.
     private let viewSpacing: CGFloat = scaledSpacing(2)
@@ -291,24 +290,19 @@ struct ProjectDetailView: View {
     }
 
     private func shareToolbarButton() -> some View {
-        Button(action: shareProgress) {
+#if os(macOS)
+        Button(action: {
+            let request = SharePreviewRequest(projectID: project.id)
+            openWindow(id: "sharePreview", value: request)
+        }) {
             Image(systemName: "square.and.arrow.up")
         }
         .help(settings.localized("share_progress_tooltip"))
-    }
-
-    private func shareProgress() {
-        guard let url = progressShareURL(for: project) else { return }
-        shareURL = url
-#if os(iOS)
-        showingShareSheet = true
 #else
-        let picker = NSSharingServicePicker(items: [url])
-        if let window = NSApplication.shared.keyWindow {
-            picker.show(relativeTo: .zero, of: window.contentView!, preferredEdge: .minY)
-        } else if let window = NSApplication.shared.windows.first {
-            picker.show(relativeTo: .zero, of: window.contentView!, preferredEdge: .minY)
+        Button(action: { showingSharePreview = true }) {
+            Image(systemName: "square.and.arrow.up")
         }
+        .help(settings.localized("share_progress_tooltip"))
 #endif
     }
 
@@ -525,13 +519,10 @@ struct ProjectDetailView: View {
             }
         }
 #if os(iOS)
-        .sheet(isPresented: $showingShareSheet, onDismiss: {
-            if let url = shareURL { try? FileManager.default.removeItem(at: url) }
-            shareURL = nil
-        }) {
-            if let url = shareURL {
-                ShareSheet(items: [url])
-            }
+        .sheet(isPresented: $showingSharePreview) {
+            ProgressSharePreview(project: project)
+                .environmentObject(settings)
+                .presentationDetents([.medium, .large])
         }
 #endif
     }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,8 @@
 "my_texts" = "My Texts";
 "select_project" = "Select a project";
 "export" = "Export";
+"share" = "Share";
+"cancel" = "Cancel";
 "import" = "Import";
 "delete_project_confirm" = "Delete project \"%@\"?";
 "cannot_undo" = "This action cannot be undone.";
@@ -75,3 +77,8 @@
 "import_project_tooltip" = "Import project";
 "toggle_sort_tooltip" = "Change sort order";
 "share_progress_tooltip" = "Share progress";
+"share_preview_circle_size" = "Circle size";
+"share_preview_ring_width" = "Ring width";
+"share_preview_percent_size" = "Percent size";
+"share_preview_title_size" = "Title size";
+"share_preview_spacing" = "Title spacing";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -22,6 +22,8 @@
 "my_texts" = "Мои тексты";
 "select_project" = "Выберите проект";
 "export" = "Экспортировать";
+"share" = "Поделиться";
+"cancel" = "Отмена";
 "import" = "Импортировать";
 "delete_project_confirm" = "Удалить проект \"%@\"?";
 "cannot_undo" = "Это действие нельзя отменить.";
@@ -75,3 +77,8 @@
 "import_project_tooltip" = "Импортировать проект";
 "toggle_sort_tooltip" = "Изменить сортировку";
 "share_progress_tooltip" = "Поделиться прогрессом";
+"share_preview_circle_size" = "Размер диаграммы";
+"share_preview_ring_width" = "Толщина круга";
+"share_preview_percent_size" = "Размер процентов";
+"share_preview_title_size" = "Размер названия";
+"share_preview_spacing" = "Расстояние";

--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -18,6 +18,10 @@ struct EditEntryRequest: Codable, Hashable {
     var entryID: UUID
 }
 
+struct SharePreviewRequest: Codable, Hashable {
+    var projectID: PersistentIdentifier
+}
+
 private func fetchProject(id: PersistentIdentifier, context: ModelContext) -> WritingProject? {
     let descriptor = FetchDescriptor<WritingProject>(
         predicate: #Predicate { $0.id == id }
@@ -105,6 +109,21 @@ extension nfprogressApp {
 #if os(macOS)
                     .windowTitle("NFProgress")
                     .windowDefaultSize(width: layoutStep(40), height: layoutStep(25))
+#endif
+            }
+        }
+        .modelContainer(DataController.shared)
+
+        WindowGroup(id: "sharePreview", for: SharePreviewRequest.self) { binding in
+            let context = ModelContext(DataController.shared)
+            if let request = binding.wrappedValue,
+               let project = fetchProject(id: request.projectID, context: context) {
+                ProgressSharePreview(project: project)
+                    .environmentObject(settings)
+                    .environment(\.locale, settings.locale)
+#if os(macOS)
+                    .windowTitle(settings.localized("share"))
+                    .windowDefaultSize(width: 560, height: 730)
 #endif
             }
         }


### PR DESCRIPTION
## Изменения
- предпросмотр уменьшает изображение на iPad в горизонтали и на iPhone, нажав на картинку можно открыть полный размер
- слайдеры заменены выпадающими списками от 1 до 100
- исправлено положение кнопок за счёт масштабирования в зависимости от ориентации

## Тестирование
- `swift test --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68595a7e774c833387ce43a84f75976c