### PR TITLE
Fix share preview layout on mac

### DIFF
--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -65,6 +65,8 @@ struct ProgressSharePreview: View {
                                    titleFontSize: titleSize,
                                    titleSpacing: spacing)
                     .scaleEffect(orientationScale)
+                    .frame(width: shareImageSize * orientationScale,
+                           height: shareImageSize * orientationScale)
                     .onTapGesture {
 #if os(iOS)
                         if !showingFullImage { showingFullImage = true }


### PR DESCRIPTION
## Summary
- make share preview allocate space for scaled export diagram on macOS

## Testing
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68598e7da90c8333a9be61147cf0ce9e