### PR TITLE
Add share title offset customization

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -14,6 +14,7 @@ let defaultShareRingWidth: Double = 24
 let defaultSharePercentSize: Double = 45
 let defaultShareTitleSize: Double = 56
 let defaultShareSpacing: Double = 16
+let defaultShareTitleOffset: Double = 0
 
 
 enum AppLanguage: String, CaseIterable, Identifiable {
@@ -109,6 +110,9 @@ final class AppSettings: ObservableObject {
     @Published var lastShareSpacing: Double {
         didSet { defaults.set(lastShareSpacing, forKey: "lastShareSpacing") }
     }
+    @Published var lastShareTitleOffset: Double {
+        didSet { defaults.set(lastShareTitleOffset, forKey: "lastShareTitleOffset") }
+    }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
@@ -132,6 +136,8 @@ final class AppSettings: ObservableObject {
         lastShareTitleSize = t == 0 ? defaultShareTitleSize : t
         let s = defaults.double(forKey: "lastShareSpacing")
         lastShareSpacing = s == 0 ? defaultShareSpacing : s
+        let o = defaults.double(forKey: "lastShareTitleOffset")
+        lastShareTitleOffset = o == 0 ? defaultShareTitleOffset : o
     }
 }
 #else
@@ -194,6 +200,9 @@ final class AppSettings {
     var lastShareSpacing: Double {
         didSet { defaults.set(lastShareSpacing, forKey: "lastShareSpacing") }
     }
+    var lastShareTitleOffset: Double {
+        didSet { defaults.set(lastShareTitleOffset, forKey: "lastShareTitleOffset") }
+    }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
@@ -217,6 +226,8 @@ final class AppSettings {
         lastShareTitleSize = t == 0 ? defaultShareTitleSize : t
         let s = defaults.double(forKey: "lastShareSpacing")
         lastShareSpacing = s == 0 ? defaultShareSpacing : s
+        let o = defaults.double(forKey: "lastShareTitleOffset")
+        lastShareTitleOffset = o == 0 ? defaultShareTitleOffset : o
     }
 }
 #endif

--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -59,6 +59,7 @@ struct ProgressShareView: View {
     var percentFontSize: CGFloat = CGFloat(defaultSharePercentSize)
     var titleFontSize: CGFloat = CGFloat(defaultShareTitleSize)
     var titleSpacing: CGFloat = CGFloat(defaultShareSpacing)
+    var titleOffset: CGFloat = CGFloat(defaultShareTitleOffset)
 
     var body: some View {
         VStack(spacing: 0) {
@@ -74,6 +75,7 @@ struct ProgressShareView: View {
                 .foregroundColor(.black)
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
+                .offset(y: titleOffset)
             Spacer()
         }
         .frame(width: shareImageSize, height: shareImageSize)
@@ -87,13 +89,15 @@ func progressShareImage(for project: WritingProject,
                         ringWidth: CGFloat = CGFloat(defaultShareRingWidth),
                         percentFontSize: CGFloat = CGFloat(defaultSharePercentSize),
                         titleFontSize: CGFloat = CGFloat(defaultShareTitleSize),
-                        titleSpacing: CGFloat = CGFloat(defaultShareSpacing)) -> OSImage? {
+                        titleSpacing: CGFloat = CGFloat(defaultShareSpacing),
+                        titleOffset: CGFloat = CGFloat(defaultShareTitleOffset)) -> OSImage? {
     let view = ProgressShareView(project: project,
                                  circleSize: circleSize,
                                  ringWidth: ringWidth,
                                  percentFontSize: percentFontSize,
                                  titleFontSize: titleFontSize,
-                                 titleSpacing: titleSpacing)
+                                 titleSpacing: titleSpacing,
+                                 titleOffset: titleOffset)
     let renderer = ImageRenderer(content: view)
 #if swift(>=5.9)
     renderer.proposedSize = ProposedViewSize(width: shareImageSize, height: shareImageSize)
@@ -116,13 +120,15 @@ func progressShareURL(for project: WritingProject,
                       ringWidth: CGFloat = CGFloat(defaultShareRingWidth),
                       percentFontSize: CGFloat = CGFloat(defaultSharePercentSize),
                       titleFontSize: CGFloat = CGFloat(defaultShareTitleSize),
-                      titleSpacing: CGFloat = CGFloat(defaultShareSpacing)) -> URL? {
+                      titleSpacing: CGFloat = CGFloat(defaultShareSpacing),
+                      titleOffset: CGFloat = CGFloat(defaultShareTitleOffset)) -> URL? {
     guard let image = progressShareImage(for: project,
                                          circleSize: circleSize,
                                          ringWidth: ringWidth,
                                          percentFontSize: percentFontSize,
                                          titleFontSize: titleFontSize,
-                                         titleSpacing: titleSpacing) else { return nil }
+                                         titleSpacing: titleSpacing,
+                                         titleOffset: titleOffset) else { return nil }
 #if canImport(UIKit)
     guard let data = image.pngData() else { return nil }
 #else

--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -15,6 +15,7 @@ struct ProgressSharePreview: View {
     @State private var percentFontPercent: Int = 100
     @State private var titleFontPercent: Int = 100
     @State private var spacingPercent: Int = 100
+    @State private var offsetPercent: Int = 0
     @State private var initialized = false
 #if os(iOS)
     @State private var shareURL: URL?
@@ -41,6 +42,9 @@ struct ProgressSharePreview: View {
     private var spacing: CGFloat {
         CGFloat(spacingPercent) / 100 * CGFloat(defaultShareSpacing)
     }
+    private var titleOffset: CGFloat {
+        CGFloat(offsetPercent) / 100 * (shareImageSize / 4)
+    }
 
     private var orientationScale: CGFloat {
 #if os(iOS)
@@ -63,8 +67,11 @@ struct ProgressSharePreview: View {
                                    ringWidth: ringWidth,
                                    percentFontSize: percentSize,
                                    titleFontSize: titleSize,
-                                   titleSpacing: spacing)
+                                   titleSpacing: spacing,
+                                   titleOffset: titleOffset)
                     .scaleEffect(orientationScale)
+                    .frame(width: shareImageSize * orientationScale,
+                           height: shareImageSize * orientationScale)
                     .onTapGesture {
 #if os(iOS)
                         if !showingFullImage { showingFullImage = true }
@@ -76,6 +83,7 @@ struct ProgressSharePreview: View {
                     controlRow(title: settings.localized("share_preview_percent_size"), value: $percentFontPercent)
                     controlRow(title: settings.localized("share_preview_title_size"), value: $titleFontPercent)
                     controlRow(title: settings.localized("share_preview_spacing"), value: $spacingPercent)
+                    controlRow(title: settings.localized("share_preview_title_offset"), value: $offsetPercent)
                 }
                 Spacer()
             }
@@ -103,6 +111,7 @@ struct ProgressSharePreview: View {
                 percentFontPercent = max(1, min(100, Int((settings.lastSharePercentSize / defaultSharePercentSize * 100).rounded())))
                 titleFontPercent = max(1, min(100, Int((settings.lastShareTitleSize / defaultShareTitleSize * 100).rounded())))
                 spacingPercent = max(1, min(100, Int((settings.lastShareSpacing / defaultShareSpacing * 100).rounded())))
+                offsetPercent = max(-100, min(100, Int((settings.lastShareTitleOffset / (shareImageSize / 4) * 100).rounded())))
                 initialized = true
             }
         }
@@ -121,12 +130,13 @@ struct ProgressSharePreview: View {
                 Color.gray.opacity(0.3).ignoresSafeArea()
                 VStack {
                     Spacer()
-                    if let img = progressShareImage(for: project,
+                   if let img = progressShareImage(for: project,
                                                   circleSize: circleSize,
                                                   ringWidth: ringWidth,
                                                   percentFontSize: percentSize,
                                                   titleFontSize: titleSize,
-                                                  titleSpacing: spacing) {
+                                                  titleSpacing: spacing,
+                                                  titleOffset: titleOffset) {
 #if os(iOS)
                         Image(uiImage: img)
 #else
@@ -157,12 +167,14 @@ struct ProgressSharePreview: View {
                                          ringWidth: ringWidth,
                                          percentFontSize: percentSize,
                                          titleFontSize: titleSize,
-                                         titleSpacing: spacing) else { return }
+                                         titleSpacing: spacing,
+                                         titleOffset: titleOffset) else { return }
         settings.lastShareCircleSize = Double(circleSize)
         settings.lastShareRingWidth = Double(ringWidth)
         settings.lastSharePercentSize = Double(percentSize)
         settings.lastShareTitleSize = Double(titleSize)
         settings.lastShareSpacing = Double(spacing)
+        settings.lastShareTitleOffset = Double(titleOffset)
 #if os(iOS)
         shareURL = url
         showingShareSheet = true
@@ -184,6 +196,7 @@ struct ProgressSharePreview: View {
                 get: { Double(value.wrappedValue) },
                 set: { value.wrappedValue = Int($0) }
             ), in: 1...100, step: 1)
+            .sliderStyle(.circular)
         }
     }
 

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -82,3 +82,4 @@
 "share_preview_percent_size" = "Percent size";
 "share_preview_title_size" = "Title size";
 "share_preview_spacing" = "Title spacing";
+"share_preview_title_offset" = "Title offset";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -82,3 +82,4 @@
 "share_preview_percent_size" = "Размер процентов";
 "share_preview_title_size" = "Размер названия";
 "share_preview_spacing" = "Расстояние";
+"share_preview_title_offset" = "Смещение названия";


### PR DESCRIPTION
## Summary
- add new default constant for share title offset
- store `lastShareTitleOffset` in settings
- allow customizing the title offset when generating share images
- expose title offset slider in share preview
- localize new option

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6859976e5258833384279190f290c370