### PR TITLE
Fix share preview build on iOS

### DIFF
--- a/nfprogress/Image+OSImage.swift
+++ b/nfprogress/Image+OSImage.swift
@@ -1,0 +1,20 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Convenience initializer to create a ``SwiftUI.Image`` from ``OSImage``.
+extension Image {
+    init(osImage: OSImage) {
+#if canImport(UIKit)
+        self.init(uiImage: osImage)
+#else
+        self.init(nsImage: osImage)
+#endif
+    }
+}
+#endif
+

--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -1,5 +1,8 @@
 #if canImport(SwiftUI)
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 #if canImport(AppKit)
 import AppKit
 #endif
@@ -137,11 +140,7 @@ struct ProgressSharePreview: View {
                                                   titleFontSize: titleSize,
                                                   titleSpacing: spacing,
                                                   titleOffset: titleOffset) {
-#if os(iOS)
-                        Image(uiImage: img)
-#else
-                        Image(nsImage: img)
-#endif
+                        Image(osImage: img)
                             .resizable()
                             .interpolation(.high)
                             .scaledToFit()


### PR DESCRIPTION
## Summary
- add cross-platform Image initializer for OSImage
- use new initializer in ProgressSharePreview

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68599fa412d48333b166805f0b26dcfe