### PR TITLE
Add Word sync on macOS

### DIFF
--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -156,6 +156,9 @@ struct ProjectDetailView: View {
         let isSelected = selectedEntry?.id == entry.id
 
         HStack {
+            if entry.isWordEntry {
+                Image(systemName: "doc")
+            }
             VStack(alignment: .leading) {
                 Text(settings.localized("characters_count", clamped))
                     .fixedSize(horizontal: false, vertical: true)
@@ -228,6 +231,9 @@ struct ProjectDetailView: View {
         let isSelected = selectedEntry?.id == entry.id
 
         HStack {
+            if entry.isWordEntry {
+                Image(systemName: "doc")
+            }
             VStack(alignment: .leading) {
                 if let stageName {
                     Text(settings.localized("stage_colon", stageName))
@@ -305,6 +311,25 @@ struct ProjectDetailView: View {
         .help(settings.localized("share_progress_tooltip"))
 #endif
     }
+
+#if os(macOS)
+    private func wordSyncToolbarButton() -> some View {
+        Button(action: { selectWordFile() }) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+        }
+        .help(settings.localized("sync_word_tooltip"))
+    }
+
+    private func selectWordFile() {
+        let panel = NSOpenPanel()
+        panel.allowedFileTypes = ["doc", "docx"]
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            project.wordFilePath = url.path
+            WordSyncManager.startMonitoring(project: project)
+        }
+    }
+#endif
 
     private func addEntry(stage: Stage? = nil) {
         #if os(macOS)
@@ -452,7 +477,17 @@ struct ProjectDetailView: View {
             if let dl = project.deadline {
                 tempDeadline = dl
             }
+#if os(macOS)
+            if project.wordFilePath != nil {
+                WordSyncManager.startMonitoring(project: project)
+            }
+#endif
         }
+#if os(macOS)
+        .onDisappear {
+            WordSyncManager.stopMonitoring(project: project)
+        }
+#endif
         #if !os(macOS)
         .sheet(isPresented: $showingAddEntry) {
             AddEntryView(project: project)
@@ -517,6 +552,11 @@ struct ProjectDetailView: View {
             ToolbarItem(placement: .primaryAction) {
                 shareToolbarButton()
             }
+#if os(macOS)
+            ToolbarItem(placement: .primaryAction) {
+                wordSyncToolbarButton()
+            }
+#endif
         }
 #if os(iOS)
         .sheet(isPresented: $showingSharePreview) {

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "import_project_tooltip" = "Import project";
 "toggle_sort_tooltip" = "Change sort order";
 "share_progress_tooltip" = "Share progress";
+"sync_word_tooltip" = "Sync with Word";
 "share_preview_circle_size" = "Circle size";
 "share_preview_ring_width" = "Ring width";
 "share_preview_percent_size" = "Percent size";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "import_project_tooltip" = "Импортировать проект";
 "toggle_sort_tooltip" = "Изменить сортировку";
 "share_progress_tooltip" = "Поделиться прогрессом";
+"sync_word_tooltip" = "Синхронизация с Word";
 "share_preview_circle_size" = "Размер диаграммы";
 "share_preview_ring_width" = "Толщина круга";
 "share_preview_percent_size" = "Размер процентов";

--- a/nfprogress/WordSyncManager.swift
+++ b/nfprogress/WordSyncManager.swift
@@ -1,0 +1,57 @@
+#if os(macOS)
+import Foundation
+import AppKit
+#if canImport(SwiftData)
+import SwiftData
+#endif
+
+@MainActor
+enum WordSyncManager {
+    private static var watchers: [PersistentIdentifier: DispatchSourceFileSystemObject] = [:]
+
+    static func startMonitoring(project: WritingProject) {
+        stopMonitoring(project: project)
+        guard let path = project.wordFilePath else { return }
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fd,
+                                                               eventMask: .write,
+                                                               queue: .main)
+        source.setEventHandler {
+            checkFile(for: project)
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        watchers[project.id] = source
+        source.resume()
+        checkFile(for: project)
+    }
+
+    static func stopMonitoring(project: WritingProject) {
+        if let source = watchers.removeValue(forKey: project.id) {
+            source.cancel()
+        }
+    }
+
+    static func checkFile(for project: WritingProject) {
+        guard let path = project.wordFilePath else { return }
+        let url = URL(fileURLWithPath: path)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modDate = attrs[.modificationDate] as? Date else { return }
+        guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
+        let count = attrString.string.count
+        if project.lastWordCharacters != count || project.lastWordModified != modDate {
+            let delta = count - project.currentProgress
+            let entry = Entry(date: modDate, characterCount: delta)
+            entry.isWordEntry = true
+            project.entries.append(entry)
+            project.lastWordCharacters = count
+            project.lastWordModified = modDate
+            let context = ModelContext(DataController.shared)
+            try? context.save()
+            NotificationCenter.default.post(name: .projectProgressChanged, object: nil)
+        }
+    }
+}
+#endif

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -13,6 +13,12 @@ class WritingProject {
     var order: Int = 0
     /// Состояние графика: `true` если график свернут
     var isChartCollapsed: Bool = false
+    /// Путь к файлу Word для синхронизации
+    var wordFilePath: String?
+    /// Количество символов в файле при последней проверке
+    var lastWordCharacters: Int?
+    /// Дата последнего изменения файла Word
+    var lastWordModified: Date?
 
     init(title: String, goal: Int, deadline: Date? = nil, order: Int = 0, isChartCollapsed: Bool = false) {
         self.title = title
@@ -267,6 +273,8 @@ class Entry: Identifiable {
     var id = UUID()
     var date: Date
     var characterCount: Int
+    /// Запись получена из Word-документа
+    var isWordEntry: Bool = false
 
     init(date: Date, characterCount: Int) {
         self.date = date


### PR DESCRIPTION
## Summary
- mark Word doc path, character count, and modification date in `WritingProject`
- track if an entry came from Word
- monitor Word files in new `WordSyncManager`
- support Word sync in Project detail view
- add translation keys for Word sync

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685a9e014c088333b0ce30859ae7b3b4