### PR TITLE
Fix Scrivener initial progress

### DIFF
--- a/nfprogress/DocumentSyncManager.swift
+++ b/nfprogress/DocumentSyncManager.swift
@@ -1,0 +1,119 @@
+#if os(macOS)
+import Foundation
+import AppKit
+#if canImport(SwiftData)
+import SwiftData
+#endif
+
+@MainActor
+enum DocumentSyncManager {
+    private static var watchers: [PersistentIdentifier: DispatchSourceFileSystemObject] = [:]
+    private static var timers: [PersistentIdentifier: Timer] = [:]
+
+    static func startMonitoring(project: WritingProject) {
+        stopMonitoring(project: project)
+        guard let type = project.syncType else { return }
+        switch type {
+        case .word:
+            guard let path = project.wordFilePath else { return }
+            startWatcher(project: project, path: path) { checkWordFile(for: project) }
+            checkWordFile(for: project)
+        case .scrivener:
+            guard let path = scrivenerFilePath(for: project) else { return }
+            startWatcher(project: project, path: path) { checkScrivenerFile(for: project) }
+            checkScrivenerFile(for: project)
+        }
+    }
+
+    static func stopMonitoring(project: WritingProject) {
+        if let source = watchers.removeValue(forKey: project.id) { source.cancel() }
+        if let timer = timers.removeValue(forKey: project.id) { timer.invalidate() }
+    }
+
+    private static func startWatcher(project: WritingProject, path: String, handler: @escaping () -> Void) {
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        let mask: DispatchSource.FileSystemEvent = [.write, .delete, .rename]
+        let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fd,
+                                                               eventMask: mask,
+                                                               queue: .main)
+        source.setEventHandler(handler: handler)
+        source.setCancelHandler { close(fd) }
+        watchers[project.id] = source
+        source.resume()
+        let timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in handler() }
+        timers[project.id] = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    static func checkWordFile(for project: WritingProject) {
+        guard let path = project.wordFilePath else { return }
+        let url = URL(fileURLWithPath: path)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modDate = attrs[.modificationDate] as? Date else { return }
+        guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
+        let count = attrString.string.count
+        if project.lastWordCharacters != count || project.lastWordModified != modDate {
+            let delta = count - project.currentProgress
+            let entry = Entry(date: modDate, characterCount: delta)
+            entry.syncSource = .word
+            project.entries.append(entry)
+            project.lastWordCharacters = count
+            project.lastWordModified = modDate
+            try? project.modelContext?.save()
+            NotificationCenter.default.post(name: .projectProgressChanged, object: nil)
+        }
+    }
+
+    private static func scrivenerFilePath(for project: WritingProject) -> String? {
+        guard let base = project.scrivenerProjectPath,
+              let itemID = project.scrivenerItemID else { return nil }
+        let baseURL = URL(fileURLWithPath: base)
+        // Modern Scrivener projects store documents in Files/Data/<UUID>/content.rtf
+        let dataURL = baseURL.appendingPathComponent("Files/Data/\(itemID)/content.rtf")
+        if FileManager.default.fileExists(atPath: dataURL.path) {
+            return dataURL.path
+        }
+
+        // Older projects keep files in Files/Docs directory with various extensions
+        let docsURL = baseURL.appendingPathComponent("Files/Docs")
+        let candidates = ["\(itemID).rtf", "\(itemID).txt", "\(itemID).rtfd/\(itemID).rtf"]
+        for name in candidates {
+            let p = docsURL.appendingPathComponent(name).path
+            if FileManager.default.fileExists(atPath: p) { return p }
+        }
+
+        if let files = try? FileManager.default.contentsOfDirectory(atPath: docsURL.path) {
+            if let match = files.first(where: { $0.hasPrefix(itemID + ".") }) {
+                return docsURL.appendingPathComponent(match).path
+            }
+        }
+
+        return nil
+    }
+
+    static func checkScrivenerFile(for project: WritingProject) {
+        guard let path = scrivenerFilePath(for: project) else { return }
+        let url = URL(fileURLWithPath: path)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modDate = attrs[.modificationDate] as? Date else { return }
+        guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
+        let count = attrString.string.count
+        if project.lastScrivenerCharacters != count || project.lastScrivenerModified != modDate {
+            let delta: Int
+            if let last = project.lastScrivenerCharacters {
+                delta = count - last
+            } else {
+                delta = count
+            }
+            let entry = Entry(date: modDate, characterCount: delta)
+            entry.syncSource = .scrivener
+            project.entries.append(entry)
+            project.lastScrivenerCharacters = count
+            project.lastScrivenerModified = modDate
+            try? project.modelContext?.save()
+            NotificationCenter.default.post(name: .projectProgressChanged, object: nil)
+        }
+    }
+}
+#endif

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -156,6 +156,11 @@ struct ProjectDetailView: View {
         let isSelected = selectedEntry?.id == entry.id
 
         HStack {
+            if entry.syncSource == .word {
+                Image(systemName: "doc")
+            } else if entry.syncSource == .scrivener {
+                Image(systemName: "doc.text")
+            }
             VStack(alignment: .leading) {
                 Text(settings.localized("characters_count", clamped))
                     .fixedSize(horizontal: false, vertical: true)
@@ -228,6 +233,11 @@ struct ProjectDetailView: View {
         let isSelected = selectedEntry?.id == entry.id
 
         HStack {
+            if entry.syncSource == .word {
+                Image(systemName: "doc")
+            } else if entry.syncSource == .scrivener {
+                Image(systemName: "doc.text")
+            }
             VStack(alignment: .leading) {
                 if let stageName {
                     Text(settings.localized("stage_colon", stageName))
@@ -305,6 +315,59 @@ struct ProjectDetailView: View {
         .help(settings.localized("share_progress_tooltip"))
 #endif
     }
+
+#if os(macOS)
+    private func wordSyncToolbarButton() -> some View {
+        Button(action: { selectSyncFile() }) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+        }
+        .help(settings.localized("sync_document_tooltip"))
+    }
+
+    private func selectSyncFile() {
+        let alert = NSAlert()
+        alert.messageText = settings.localized("sync_type_prompt")
+        alert.addButton(withTitle: settings.localized("sync_type_word"))
+        alert.addButton(withTitle: settings.localized("sync_type_scrivener"))
+        let result = alert.runModal()
+        switch result {
+        case .alertFirstButtonReturn:
+            project.syncType = .word
+            let panel = NSOpenPanel()
+            panel.allowedFileTypes = ["doc", "docx"]
+            panel.allowsMultipleSelection = false
+            if panel.runModal() == .OK, let url = panel.url {
+                project.wordFilePath = url.path
+                DocumentSyncManager.startMonitoring(project: project)
+            }
+        case .alertSecondButtonReturn:
+            project.syncType = .scrivener
+            let panel = NSOpenPanel()
+            panel.allowedFileTypes = ["scriv"]
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = false
+            panel.allowsMultipleSelection = false
+            if panel.runModal() == .OK, let url = panel.url {
+                selectScrivenerItem(projectURL: url)
+            }
+        default:
+            break
+        }
+    }
+
+    private func selectScrivenerItem(projectURL: URL) {
+        let items = ScrivenerParser.items(in: projectURL)
+        guard !items.isEmpty else {
+            let alert = NSAlert()
+            alert.messageText = settings.localized("scrivener_parse_error")
+            alert.runModal()
+            return
+        }
+
+        let request = ScrivenerSelectRequest(projectID: project.id, projectPath: projectURL.path)
+        openWindow(id: "selectScrivenerItem", value: request)
+    }
+#endif
 
     private func addEntry(stage: Stage? = nil) {
         #if os(macOS)
@@ -452,7 +515,17 @@ struct ProjectDetailView: View {
             if let dl = project.deadline {
                 tempDeadline = dl
             }
+#if os(macOS)
+            if project.syncType != nil {
+                DocumentSyncManager.startMonitoring(project: project)
+            }
+#endif
         }
+#if os(macOS)
+        .onDisappear {
+            DocumentSyncManager.stopMonitoring(project: project)
+        }
+#endif
         #if !os(macOS)
         .sheet(isPresented: $showingAddEntry) {
             AddEntryView(project: project)
@@ -517,6 +590,11 @@ struct ProjectDetailView: View {
             ToolbarItem(placement: .primaryAction) {
                 shareToolbarButton()
             }
+#if os(macOS)
+            ToolbarItem(placement: .primaryAction) {
+                wordSyncToolbarButton()
+            }
+#endif
         }
 #if os(iOS)
         .sheet(isPresented: $showingSharePreview) {

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -77,9 +77,15 @@
 "import_project_tooltip" = "Import project";
 "toggle_sort_tooltip" = "Change sort order";
 "share_progress_tooltip" = "Share progress";
+"sync_document_tooltip" = "Sync document";
+"sync_type_prompt" = "Select sync source";
+"sync_type_word" = "Word";
+"sync_type_scrivener" = "Scrivener";
+"scrivener_choose_item" = "Select item";
 "share_preview_circle_size" = "Circle size";
 "share_preview_ring_width" = "Ring width";
 "share_preview_percent_size" = "Percent size";
 "share_preview_title_size" = "Title size";
 "share_preview_spacing" = "Title spacing";
 "charts_framework_required" = "Charts framework is required";
+"scrivener_parse_error" = "Failed to load Scrivener project";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -77,9 +77,15 @@
 "import_project_tooltip" = "Импортировать проект";
 "toggle_sort_tooltip" = "Изменить сортировку";
 "share_progress_tooltip" = "Поделиться прогрессом";
+"sync_document_tooltip" = "Синхронизация";
+"sync_type_prompt" = "Выберите источник";
+"sync_type_word" = "Word";
+"sync_type_scrivener" = "Scrivener";
+"scrivener_choose_item" = "Выбор элемента";
 "share_preview_circle_size" = "Размер диаграммы";
 "share_preview_ring_width" = "Толщина круга";
 "share_preview_percent_size" = "Размер процентов";
 "share_preview_title_size" = "Размер названия";
 "share_preview_spacing" = "Расстояние";
 "charts_framework_required" = "Для отображения графика требуется фреймворк Charts";
+"scrivener_parse_error" = "Не удалось загрузить проект Scrivener";

--- a/nfprogress/ScrivenerItemSelectView.swift
+++ b/nfprogress/ScrivenerItemSelectView.swift
@@ -1,0 +1,92 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+struct ScrivenerItemSelectView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var settings: AppSettings
+    @Bindable var project: WritingProject
+    let projectURL: URL
+    private let items: [ScrivenerItem]
+    @State private var selection: ScrivenerItem?
+
+    init(project: WritingProject, projectURL: URL) {
+        self.project = project
+        self.projectURL = projectURL
+        self.items = ScrivenerParser.items(in: projectURL)
+    }
+
+    private var defaultWidth: CGFloat {
+        let frame = NSScreen.main?.visibleFrame ?? .init(x: 0, y: 0, width: 800, height: 600)
+        return min(frame.width * 0.6, layoutStep(60))
+    }
+
+    private var defaultHeight: CGFloat {
+        let frame = NSScreen.main?.visibleFrame ?? .init(x: 0, y: 0, width: 800, height: 600)
+        return min(frame.height * 0.6, layoutStep(50))
+    }
+
+    var body: some View {
+        VStack(spacing: scaledSpacing()) {
+            Outline(items: items, selection: $selection)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            HStack {
+                Spacer()
+                Button(settings.localized("cancel")) { dismiss() }
+                Button(settings.localized("done")) { confirm() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .scaledPadding()
+        .frame(minWidth: layoutStep(40), minHeight: layoutStep(30))
+        .windowMinWidth(layoutStep(40))
+        .windowDefaultSize(width: defaultWidth, height: defaultHeight)
+        .windowTitle(settings.localized("scrivener_choose_item"))
+    }
+
+    private func confirm() {
+        guard let item = selection else { return }
+        project.scrivenerProjectPath = projectURL.path
+        project.scrivenerItemID = item.id
+        DocumentSyncManager.startMonitoring(project: project)
+        try? project.modelContext?.save()
+        dismiss()
+    }
+
+    private struct Outline: NSViewRepresentable {
+        var items: [ScrivenerItem]
+        @Binding var selection: ScrivenerItem?
+
+        func makeCoordinator() -> ScrivenerOutlineDataSource {
+            ScrivenerOutlineDataSource(items: items) { item in
+                selection = item
+            }
+        }
+
+        func makeNSView(context: Context) -> NSScrollView {
+            let outline = NSOutlineView()
+            let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("title"))
+            outline.addTableColumn(column)
+            outline.outlineTableColumn = column
+            outline.headerView = nil
+            outline.dataSource = context.coordinator
+            outline.delegate = context.coordinator
+            outline.rowSizeStyle = .small
+            outline.reloadData()
+            outline.expandItem(nil, expandChildren: true)
+            let scroll = NSScrollView()
+            scroll.hasVerticalScroller = true
+            scroll.documentView = outline
+            return scroll
+        }
+
+        func updateNSView(_ nsView: NSScrollView, context: Context) {
+            context.coordinator.items = items
+            if let outline = nsView.documentView as? NSOutlineView {
+                outline.reloadData()
+                outline.expandItem(nil, expandChildren: true)
+            }
+        }
+    }
+}
+#endif

--- a/nfprogress/ScrivenerOutlineDataSource.swift
+++ b/nfprogress/ScrivenerOutlineDataSource.swift
@@ -1,0 +1,56 @@
+#if os(macOS)
+import Cocoa
+
+final class ScrivenerOutlineDataSource: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
+    var items: [ScrivenerItem]
+    var selectionHandler: ((ScrivenerItem) -> Void)?
+
+    init(items: [ScrivenerItem], selectionHandler: ((ScrivenerItem) -> Void)? = nil) {
+        self.items = items
+        self.selectionHandler = selectionHandler
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+        let node = item as? ScrivenerItem
+        return node?.children.count ?? items.count
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
+        let node = item as! ScrivenerItem
+        return !node.children.isEmpty
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+        let node = item as? ScrivenerItem
+        return node?.children[index] ?? items[index]
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+        guard let node = item as? ScrivenerItem else { return nil }
+        let identifier = NSUserInterfaceItemIdentifier("cell")
+        let cell = outlineView.makeView(withIdentifier: identifier, owner: nil) as? NSTableCellView ?? NSTableCellView()
+        cell.identifier = identifier
+        if cell.textField == nil {
+            let textField = NSTextField(labelWithString: node.title)
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            cell.addSubview(textField)
+            cell.textField = textField
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 2),
+                textField.centerYAnchor.constraint(equalTo: cell.centerYAnchor)
+            ])
+        } else {
+            cell.textField?.stringValue = node.title
+        }
+        return cell
+    }
+
+    func outlineViewSelectionDidChange(_ notification: Notification) {
+        guard let outline = notification.object as? NSOutlineView else { return }
+        let row = outline.selectedRow
+        if row >= 0, let item = outline.item(atRow: row) as? ScrivenerItem {
+            selectionHandler?(item)
+        }
+    }
+}
+#endif

--- a/nfprogress/ScrivenerParser.swift
+++ b/nfprogress/ScrivenerParser.swift
@@ -1,0 +1,59 @@
+#if os(macOS)
+import Foundation
+
+class ScrivenerItem: NSObject {
+    let id: String
+    let title: String
+    let children: [ScrivenerItem]
+
+    init(id: String, title: String, children: [ScrivenerItem] = []) {
+        self.id = id
+        self.title = title
+        self.children = children
+    }
+}
+
+enum ScrivenerParser {
+    /// Возвращает структуру проекта Scrivener по пути к пакету проекта.
+    /// Поддерживаются проекты разных версий:
+    ///  - стандартный файл `project.scrivx`
+    ///  - файл с именем проекта и расширением `.scrivx`
+    ///  - устаревший `binder.scrivproj`
+    static func items(in projectURL: URL) -> [ScrivenerItem] {
+        var xmlURL = projectURL.appendingPathComponent("project.scrivx")
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: xmlURL.path) {
+            if let name = try? fm.contentsOfDirectory(atPath: projectURL.path)
+                .first(where: { $0.hasSuffix(".scrivx") }) {
+                xmlURL = projectURL.appendingPathComponent(name)
+            } else {
+                xmlURL = projectURL.appendingPathComponent("binder.scrivproj")
+            }
+        }
+        guard fm.fileExists(atPath: xmlURL.path),
+              let data = try? Data(contentsOf: xmlURL),
+              let doc = try? XMLDocument(data: data) else { return [] }
+
+        // В разных версиях Scrivener корневой элемент отличается, поэтому
+        // ищем первый подходящий узел
+        let binder = (try? doc.nodes(forXPath: "//Binder"))?.first as? XMLElement ??
+                     (try? doc.nodes(forXPath: "//root"))?.first as? XMLElement
+        guard let binderNode = binder else { return [] }
+        return binderNode.elements(forName: "BinderItem").compactMap { parseItem($0) }
+    }
+
+    private static func parseItem(_ element: XMLElement) -> ScrivenerItem? {
+        let id = element.attribute(forName: "UUID")?.stringValue ??
+                 element.attribute(forName: "Uuid")?.stringValue ??
+                 element.attribute(forName: "uuid")?.stringValue ??
+                 element.attribute(forName: "ID")?.stringValue
+        guard let id, let title = element.elements(forName: "Title").first?.stringValue else { return nil }
+        let childContainer = element.elements(forName: "Children").first ??
+                              element.elements(forName: "SubDocuments").first
+        let childElements = childContainer?.elements(forName: "BinderItem") ??
+                            element.elements(forName: "BinderItem")
+        let children = childElements.compactMap { parseItem($0) }
+        return ScrivenerItem(id: id, title: title, children: children)
+    }
+}
+#endif

--- a/nfprogress/SyncDocumentType.swift
+++ b/nfprogress/SyncDocumentType.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum SyncDocumentType: String, Codable {
+    case word
+    case scrivener
+}

--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -22,6 +22,11 @@ struct SharePreviewRequest: Codable, Hashable {
     var projectID: PersistentIdentifier
 }
 
+struct ScrivenerSelectRequest: Codable, Hashable {
+    var projectID: PersistentIdentifier
+    var projectPath: String
+}
+
 private func fetchProject(id: PersistentIdentifier, context: ModelContext) -> WritingProject? {
     let descriptor = FetchDescriptor<WritingProject>(
         predicate: #Predicate { $0.id == id }
@@ -125,6 +130,18 @@ extension nfprogressApp {
                     .windowTitle(settings.localized("share"))
                     .windowDefaultSize(width: 560, height: 730)
 #endif
+            }
+        }
+        .modelContainer(DataController.shared)
+
+        WindowGroup(id: "selectScrivenerItem", for: ScrivenerSelectRequest.self) { binding in
+            let context = ModelContext(DataController.shared)
+            if let request = binding.wrappedValue,
+               let project = fetchProject(id: request.projectID, context: context) {
+                let url = URL(fileURLWithPath: request.projectPath)
+                ScrivenerItemSelectView(project: project, projectURL: url)
+                    .environmentObject(settings)
+                    .environment(\.locale, settings.locale)
             }
         }
         .modelContainer(DataController.shared)

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -13,6 +13,20 @@ class WritingProject {
     var order: Int = 0
     /// Состояние графика: `true` если график свернут
     var isChartCollapsed: Bool = false
+    /// Тип синхронизации документа
+    var syncType: SyncDocumentType?
+    /// Путь к файлу Word для синхронизации
+    var wordFilePath: String?
+    /// Путь к проекту Scrivener
+    var scrivenerProjectPath: String?
+    /// Выбранный ID элемента Scrivener
+    var scrivenerItemID: String?
+    /// Количество символов в файле при последней проверке
+    var lastWordCharacters: Int?
+    var lastScrivenerCharacters: Int?
+    /// Дата последнего изменения файла Word
+    var lastWordModified: Date?
+    var lastScrivenerModified: Date?
 
     init(title: String, goal: Int, deadline: Date? = nil, order: Int = 0, isChartCollapsed: Bool = false) {
         self.title = title
@@ -267,6 +281,8 @@ class Entry: Identifiable {
     var id = UUID()
     var date: Date
     var characterCount: Int
+    /// Источник синхронизации
+    var syncSource: SyncDocumentType?
 
     init(date: Date, characterCount: Int) {
         self.date = date


### PR DESCRIPTION
## Summary
- prefer UUID when parsing binder items so associated file is found
- persist project changes when selecting Scrivener item
- save entries using the project's context

## Testing
- `swift test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_685a9e014c088333b0ce30859ae7b3b4