### PR TITLE
Fix window size persistence

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -13,9 +13,9 @@ import AppKit
 struct ContentView: View {
   @Environment(\.modelContext) private var modelContext
   @EnvironmentObject private var settings: AppSettings
-  #if os(macOS)
+#if os(macOS)
   @Environment(\.openWindow) private var openWindow
-  #endif
+#endif
   @Query(sort: [SortDescriptor(\WritingProject.order)]) private var projects: [WritingProject]
   @State private var selectedProject: WritingProject?
   /// Проект, открытый в навигационном стеке на iPhone
@@ -25,6 +25,13 @@ struct ContentView: View {
   @State private var showingAddProject = false
   @State private var projectToDelete: WritingProject?
   @State private var showDeleteAlert = false
+#if os(macOS)
+  @AppStorage("sidebarWidth") private var sidebarWidthRaw: Double = 405
+  private var sidebarWidth: CGFloat {
+    get { CGFloat(sidebarWidthRaw) }
+    nonmutating set { sidebarWidthRaw = Double(newValue) }
+  }
+#endif
 
   private let circleHeight: CGFloat = layoutStep(10)
 #if os(macOS)
@@ -131,6 +138,7 @@ struct ContentView: View {
       .listStyle(.plain)
       .navigationTitle("my_texts")
       .toolbar { toolbarContent }
+      .background(SidebarWidthReader())
     }, detail: {
       if let project = selectedProject {
         ProjectDetailView(project: project)
@@ -140,7 +148,10 @@ struct ContentView: View {
       }
     })
 #if os(macOS)
-    .navigationSplitViewColumnWidth(405)
+    .navigationSplitViewColumnWidth(min: minWindowWidth, ideal: sidebarWidth, max: .infinity)
+    .onPreferenceChange(SidebarWidthKey.self) { width in
+      sidebarWidth = width
+    }
 #endif
     .navigationDestination(for: WritingProject.self) { project in
       ProjectDetailView(project: project)
@@ -481,4 +492,20 @@ struct ContentView: View {
     try? modelContext.save()
   }
 }
+#if os(macOS)
+private struct SidebarWidthKey: PreferenceKey {
+  static var defaultValue: CGFloat = 405
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = nextValue()
+  }
+}
+
+private struct SidebarWidthReader: View {
+  var body: some View {
+    GeometryReader { proxy in
+      Color.clear.preference(key: SidebarWidthKey.self, value: proxy.size.width)
+    }
+  }
+}
+#endif
 #endif

--- a/nfprogress/WindowDefaultSizeModifier.swift
+++ b/nfprogress/WindowDefaultSizeModifier.swift
@@ -25,6 +25,14 @@ private struct WindowDefaultSizeSetter: NSViewRepresentable {
     private func apply(to view: NSView, coordinator: Coordinator) {
         guard let window = view.window, !coordinator.applied else { return }
         coordinator.applied = true
+
+        if !window.frameAutosaveName.isEmpty {
+            let key = "NSWindow Frame \(window.frameAutosaveName)"
+            if UserDefaults.standard.object(forKey: key) != nil {
+                return
+            }
+        }
+
         var frame = window.frame
         frame.size = NSSize(width: width, height: height)
         window.setFrame(frame, display: true)

--- a/nfprogress/WindowFramePersistence.swift
+++ b/nfprogress/WindowFramePersistence.swift
@@ -1,0 +1,30 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+private struct WindowFramePersistence: NSViewRepresentable {
+    var id: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { apply(to: view) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { apply(to: nsView) }
+    }
+
+    private func apply(to view: NSView) {
+        guard let window = view.window else { return }
+        window.setFrameAutosaveName(id)
+    }
+}
+
+extension View {
+    /// Сохраняет и восстанавливает положение и размер окна macOS.
+    func persistentWindowFrame(id: String = "main") -> some View {
+        background(WindowFramePersistence(id: id))
+    }
+}
+#endif

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -41,6 +41,7 @@ struct nfprogressApp: App {
                 .environment(\.locale, settings.locale)
 #if os(macOS)
                 .windowTitle("NFProgress")
+                .persistentWindowFrame()
                 .windowDefaultSize(width: 810, height: 530)
 #endif
         }


### PR DESCRIPTION
## Summary
- prevent `windowDefaultSize` from overriding restored frame if a saved size exists
- apply `.persistentWindowFrame()` before setting the default size

## Testing
- `swift build`
- `swift test -l`


------
https://chatgpt.com/codex/tasks/task_e_685bd59186b083338c0ca54cfb5281d1