### PR TITLE
Improve progress chart axis labeling

### DIFF
--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -321,14 +321,17 @@ struct ProgressChartView: View {
                             .foregroundStyle(.blue)
                         }
                     }
+                    .chartXScale(domain: (project.sortedEntries.first?.date ?? Date())...(project.sortedEntries.last?.date ?? Date()))
                     .chartXAxis {
-                        let comp = project.sortedEntryDates.stride(forWidth: geo.size.width)
-                        AxisMarks(values: .stride(by: comp)) { value in
-                            if let date = value.as(Date.self) {
-                                AxisGridLine()
-                                AxisTick()
-                                AxisValueLabel {
-                                    Text(date.formatted(date: .numeric, time: .shortened))
+                        if let first = project.sortedEntries.first?.date,
+                           let last = project.sortedEntries.last?.date {
+                            AxisMarks(values: [first, last]) { value in
+                                if let date = value.as(Date.self) {
+                                    AxisGridLine()
+                                    AxisTick()
+                                    AxisValueLabel {
+                                        Text(date.formatted(date: .numeric, time: .shortened))
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- show only first and last entry dates on project progress chart
- ensure x-axis range includes both endpoints

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685c098ad2bc8333a923e16cf2a205e1