### PR TITLE
Fix progress chart axis

### DIFF
--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -321,9 +321,10 @@ struct ProgressChartView: View {
                             .foregroundStyle(.blue)
                         }
                     }
+                    .chartXScale(domain: (project.sortedEntries.first?.date ?? Date())...(project.sortedEntries.last?.date ?? Date()))
                     .chartXAxis {
-                        if let first = project.sortedEntryDates.first,
-                           let last = project.sortedEntryDates.last {
+                        if let first = project.sortedEntries.first?.date,
+                           let last = project.sortedEntries.last?.date {
                             AxisMarks(values: [first, last]) { value in
                                 if let date = value.as(Date.self) {
                                     AxisGridLine()


### PR DESCRIPTION
## Summary
- display only the first and last date on the progress chart's axis
- fix X scale domain for full dataset span

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685c0ecca7908333ad84602fe41e21a1