### PR TITLE
Fix progress chart axis domain

### DIFF
--- a/nfprogress/ChartStride.swift
+++ b/nfprogress/ChartStride.swift
@@ -47,5 +47,24 @@ extension WritingProject {
         let dates = sortedEntries.map { calendar.startOfDay(for: $0.date) }
         return Array(Set(dates)).sorted()
     }
+
+    /// Даты записей с вариантами подписи для оси графика.
+    var entryAxisInfo: [(date: Date, label: String)] {
+        let calendar = Calendar.current
+        var lastDay: Date?
+        var result: [(Date, String)] = []
+        for entry in sortedEntries {
+            let day = calendar.startOfDay(for: entry.date)
+            let label: String
+            if day != lastDay {
+                label = entry.date.formatted(date: .numeric, time: .shortened)
+            } else {
+                label = entry.date.formatted(date: .omitted, time: .shortened)
+            }
+            result.append((entry.date, label))
+            lastDay = day
+        }
+        return result
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- корректируем домен оси X для учёта всех дней от первой записи до дня после последней
- сохраняем отображение отметок по каждой записи и вертикальную прокрутку графика
- исправляем вызов `chartXScale` для совместимости с Charts
- добавляем горизонтальную прокрутку графика

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685c0ecca7908333ad84602fe41e21a1