### PR TITLE
Fix progress chart layout

### DIFF
--- a/nfprogress/ChartStride.swift
+++ b/nfprogress/ChartStride.swift
@@ -47,5 +47,26 @@ extension WritingProject {
         let dates = sortedEntries.map { calendar.startOfDay(for: $0.date) }
         return Array(Set(dates)).sorted()
     }
+
+    /// Подписи для оси графика в порядке записей.
+    /// Каждой записи соответствует текст, содержащий дату и время
+    /// (при нескольких записях в день показывается только время).
+    var entryAxisLabels: [String] {
+        let calendar = Calendar.current
+        var lastDay: Date?
+        var result: [String] = []
+        for entry in sortedEntries {
+            let day = calendar.startOfDay(for: entry.date)
+            let label: String
+            if day != lastDay {
+                label = entry.date.formatted(date: .numeric, time: .shortened)
+            } else {
+                label = entry.date.formatted(date: .omitted, time: .shortened)
+            }
+            result.append(label)
+            lastDay = day
+        }
+        return result
+    }
 }
 #endif

--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -280,6 +280,8 @@ struct ProgressChartView: View {
 
     private let viewSpacing: CGFloat = scaledSpacing(1)
     private let chartHeight: CGFloat = layoutStep(25)
+    /// Минимальное расстояние между подписями оси X
+    private let minLabelSpacing: CGFloat = 80
 
     var body: some View {
         VStack(alignment: .leading, spacing: viewSpacing) {
@@ -299,46 +301,55 @@ struct ProgressChartView: View {
             if project.sortedEntries.count >= 2 {
 #if canImport(Charts)
                 GeometryReader { geo in
-                    Chart {
-                        // Целевая линия
-                        RuleMark(y: .value(settings.localized("progress_chart_goal"), project.goal))
-                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
-                            .foregroundStyle(.gray)
-                            .annotation(position: .top, alignment: .leading) {
-                            Text(settings.localized("goal_characters", project.goal))
-                                .font(.caption)
-                                .foregroundColor(.gray)
-                        }
+                    let labels = project.entryAxisLabels
+                    let entries = Array(project.sortedEntries.enumerated())
+                    let width = max(geo.size.width,
+                                    CGFloat(labels.count) * minLabelSpacing)
+                    ScrollView([.horizontal, .vertical]) {
+                        Chart {
+                            // Целевая линия
+                            RuleMark(y: .value(settings.localized("progress_chart_goal"), project.goal))
+                                .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                                .foregroundStyle(.gray)
+                                .annotation(position: .top, alignment: .leading) {
+                                    Text(settings.localized("goal_characters", project.goal))
+                                        .font(.caption)
+                                        .foregroundColor(.gray)
+                                }
 
-                        // Линия прогресса
-                        ForEach(project.sortedEntries) { entry in
-                            LineMark(
-                                x: .value(settings.localized("date_field"), entry.date),
-                                y: .value(settings.localized("characters_field"), project.globalProgress(for: entry))
-                            )
-                            .interpolationMethod(.monotone)
-                            .symbol(.circle)
-                            .foregroundStyle(.blue)
+                            // Линия прогресса
+                            ForEach(entries, id: \.1.id) { index, entry in
+                                LineMark(
+                                    x: .value(settings.localized("date_field"), index),
+                                    y: .value(settings.localized("characters_field"), project.globalProgress(for: entry))
+                                )
+                                .interpolationMethod(.monotone)
+                                .symbol(.circle)
+                                .foregroundStyle(.blue)
+                            }
                         }
-                    }
-                    .chartXAxis {
-                        if let first = project.sortedEntryDates.first,
-                           let last = project.sortedEntryDates.last {
-                            AxisMarks(values: [first, last]) { value in
-                                if let date = value.as(Date.self) {
+                        .chartXScale(domain: 0...max(labels.count - 1, 0))
+                        .chartScrollableAxes(.horizontal)
+                        .chartXVisibleDomain(length: {
+                            let visible = min(labels.count, 7)
+                            return Double(max(visible - 1, 1))
+                        }())
+                        .chartXAxis {
+                            AxisMarks(values: Array(labels.indices)) { value in
+                                if let i = value.as(Int.self), i < labels.count {
                                     AxisGridLine()
                                     AxisTick()
                                     AxisValueLabel {
-                                        Text(date.formatted(date: .numeric, time: .shortened))
+                                        Text(labels[i])
                                     }
                                 }
                             }
                         }
+                        .frame(width: width, alignment: .leading)
                     }
-                    .frame(maxWidth: .infinity)
+                    .frame(height: chartHeight, alignment: .top)
                 }
-                .frame(height: chartHeight, alignment: .top)
-#else
+                #else
                 Text("charts_framework_required")
                     .frame(height: chartHeight, alignment: .top)
 #endif


### PR DESCRIPTION
## Summary
- adapt progress chart axis to use entry indexes instead of dates
- provide per-entry axis labels and show final entry label
- keep chart scrollable in both directions

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685c0ecca7908333ad84602fe41e21a1