### PR TITLE
Fix progress chart layout

### DIFF
--- a/nfprogress/ChartStride.swift
+++ b/nfprogress/ChartStride.swift
@@ -47,5 +47,26 @@ extension WritingProject {
         let dates = sortedEntries.map { calendar.startOfDay(for: $0.date) }
         return Array(Set(dates)).sorted()
     }
+
+    /// Подписи для оси графика в порядке записей.
+    /// Каждой записи соответствует текст, содержащий дату и время
+    /// (при нескольких записях в день показывается только время).
+    var entryAxisLabels: [String] {
+        let calendar = Calendar.current
+        var lastDay: Date?
+        var result: [String] = []
+        for entry in sortedEntries {
+            let day = calendar.startOfDay(for: entry.date)
+            let label: String
+            if day != lastDay {
+                label = entry.date.formatted(date: .numeric, time: .shortened)
+            } else {
+                label = entry.date.formatted(date: .omitted, time: .shortened)
+            }
+            result.append(label)
+            lastDay = day
+        }
+        return result
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- adapt progress chart axis to use entry indexes instead of dates
- provide per-entry axis labels and show final entry label
- keep chart scrollable in both directions
- add bottom padding after chart to avoid overlapping with other content

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685c0ecca7908333ad84602fe41e21a1