### PR TITLE
Add sync settings and pause controls

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -115,6 +115,24 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(lastShareTitleOffset, forKey: "lastShareTitleOffset") }
     }
 
+    @Published var syncInterval: Double {
+        didSet {
+            defaults.set(syncInterval, forKey: "syncInterval")
+            #if os(macOS)
+            DocumentSyncManager.updateSyncInterval(to: syncInterval)
+            #endif
+        }
+    }
+
+    @Published var pauseAllSync: Bool {
+        didSet {
+            defaults.set(pauseAllSync, forKey: "pauseAllSync")
+            #if os(macOS)
+            DocumentSyncManager.setGlobalPause(pauseAllSync)
+            #endif
+        }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -139,6 +157,9 @@ final class AppSettings: ObservableObject {
         lastShareSpacing = s == 0 ? defaultShareSpacing : s
         let o = defaults.double(forKey: "lastShareTitleOffset")
         lastShareTitleOffset = o == 0 ? defaultShareTitleOffset : o
+        let i = defaults.double(forKey: "syncInterval")
+        syncInterval = i == 0 ? 2 : i
+        pauseAllSync = defaults.bool(forKey: "pauseAllSync")
     }
 }
 #else
@@ -205,6 +226,24 @@ final class AppSettings {
         didSet { defaults.set(lastShareTitleOffset, forKey: "lastShareTitleOffset") }
     }
 
+    var syncInterval: Double {
+        didSet {
+            defaults.set(syncInterval, forKey: "syncInterval")
+            #if os(macOS)
+            DocumentSyncManager.updateSyncInterval(to: syncInterval)
+            #endif
+        }
+    }
+
+    var pauseAllSync: Bool {
+        didSet {
+            defaults.set(pauseAllSync, forKey: "pauseAllSync")
+            #if os(macOS)
+            DocumentSyncManager.setGlobalPause(pauseAllSync)
+            #endif
+        }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -229,6 +268,9 @@ final class AppSettings {
         lastShareSpacing = s == 0 ? defaultShareSpacing : s
         let o = defaults.double(forKey: "lastShareTitleOffset")
         lastShareTitleOffset = o == 0 ? defaultShareTitleOffset : o
+        let i = defaults.double(forKey: "syncInterval")
+        syncInterval = i == 0 ? 2 : i
+        pauseAllSync = defaults.bool(forKey: "pauseAllSync")
     }
 }
 #endif

--- a/nfprogress/DocumentSyncInfoView.swift
+++ b/nfprogress/DocumentSyncInfoView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct DocumentSyncInfoView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
     @EnvironmentObject private var settings: AppSettings
     @Bindable var project: WritingProject
 
@@ -33,6 +34,15 @@ struct DocumentSyncInfoView: View {
         VStack(spacing: scaledSpacing()) {
             Text(info)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            Toggle(settings.localized("pause_sync"), isOn: $project.syncPaused)
+                .toggleStyle(.switch)
+                .onChange(of: project.syncPaused) { value in
+                    if value { DocumentSyncManager.stopMonitoring(project: project) }
+                    else { DocumentSyncManager.startMonitoring(project: project) }
+                }
+            if project.syncType == .scrivener {
+                Button(settings.localized("change")) { changeItem() }
+            }
             Spacer()
             HStack {
                 Spacer()
@@ -48,6 +58,14 @@ struct DocumentSyncInfoView: View {
 
     private func unlink() {
         DocumentSyncManager.removeSync(project: project)
+        dismiss()
+    }
+
+    private func changeItem() {
+        guard let basePath = DocumentSyncManager.resolvedPath(bookmark: project.scrivenerProjectBookmark,
+                                                               path: project.scrivenerProjectPath) else { return }
+        let request = ScrivenerSelectRequest(projectID: project.id, projectPath: basePath)
+        openWindow(id: "selectScrivenerItem", value: request)
         dismiss()
     }
 }

--- a/nfprogress/DocumentSyncManager.swift
+++ b/nfprogress/DocumentSyncManager.swift
@@ -13,6 +13,82 @@ enum DocumentSyncManager {
     private static var stageWatchers: [UUID: DispatchSourceFileSystemObject] = [:]
     private static var stageTimers: [UUID: Timer] = [:]
     private static var stageAccessURLs: [UUID: URL] = [:]
+    private static var syncInterval: TimeInterval = {
+        let v = UserDefaults.standard.double(forKey: "syncInterval")
+        return v == 0 ? 2 : v
+    }()
+    private static var globallyPaused: Bool = UserDefaults.standard.bool(forKey: "pauseAllSync")
+
+    static func updateSyncInterval(to value: TimeInterval) {
+        syncInterval = value
+        refreshAllTimers()
+    }
+
+    static func setGlobalPause(_ paused: Bool) {
+        globallyPaused = paused
+        if paused {
+            stopAllMonitoring()
+        } else {
+            startAllMonitoring()
+        }
+    }
+
+    private static func stopAllMonitoring() {
+        let context = DataController.mainContext
+        let desc = FetchDescriptor<WritingProject>()
+        if let projects = try? context.fetch(desc) {
+            for project in projects where project.syncType != nil {
+                stopMonitoring(project: project)
+            }
+            for stage in projects.flatMap({ $0.stages }) where stage.syncType != nil {
+                stopMonitoring(stage: stage)
+            }
+        }
+    }
+
+    private static func startAllMonitoring() {
+        let context = DataController.mainContext
+        let desc = FetchDescriptor<WritingProject>()
+        if let projects = try? context.fetch(desc) {
+            for project in projects where project.syncType != nil && !project.syncPaused {
+                startMonitoring(project: project)
+            }
+            for stage in projects.flatMap({ $0.stages }) where stage.syncType != nil && !stage.syncPaused {
+                startMonitoring(stage: stage)
+            }
+        }
+    }
+
+    private static func refreshAllTimers() {
+        for (id, timer) in timers {
+            timer.invalidate()
+            guard let project = fetchProject(id: id) else { continue }
+            let handler: () -> Void = {
+                switch project.syncType {
+                case .word: checkWordFile(for: id)
+                case .scrivener: checkScrivenerFile(for: id)
+                case .none: break
+                }
+            }
+            let t = Timer.scheduledTimer(withTimeInterval: syncInterval, repeats: true) { _ in handler() }
+            timers[id] = t
+            RunLoop.main.add(t, forMode: .common)
+        }
+        for (id, timer) in stageTimers {
+            timer.invalidate()
+            guard let stage = fetchStage(id: id) else { continue }
+            let handler: () -> Void = {
+                switch stage.syncType {
+                case .word: checkWordFile(stageID: id)
+                case .scrivener: checkScrivenerFile(stageID: id)
+                case .none: break
+                }
+            }
+            let t = Timer.scheduledTimer(withTimeInterval: syncInterval, repeats: true) { _ in handler() }
+            stageTimers[id] = t
+            RunLoop.main.add(t, forMode: .common)
+        }
+    }
 
     /// Возвращает идентификатор проекта, которому принадлежит этап
     private static func projectID(for stage: Stage) -> PersistentIdentifier? {
@@ -74,7 +150,7 @@ enum DocumentSyncManager {
 
     static func startMonitoring(project: WritingProject) {
         stopMonitoring(project: project)
-        guard let type = project.syncType else { return }
+        guard !globallyPaused, !project.syncPaused, let type = project.syncType else { return }
         let id = project.id
         switch type {
         case .word:
@@ -154,7 +230,7 @@ enum DocumentSyncManager {
         source.setCancelHandler { close(fd) }
         watchers[projectID] = source
         source.resume()
-        let timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { _ in handler() }
+        let timer = Timer.scheduledTimer(withTimeInterval: syncInterval, repeats: true) { _ in handler() }
         timers[projectID] = timer
         RunLoop.main.add(timer, forMode: .common)
     }
@@ -183,7 +259,7 @@ enum DocumentSyncManager {
 
     static func startMonitoring(stage: Stage) {
         stopMonitoring(stage: stage)
-        guard let type = stage.syncType else { return }
+        guard !globallyPaused, !stage.syncPaused, let type = stage.syncType else { return }
         let id = stage.id
         switch type {
         case .word:
@@ -262,7 +338,7 @@ enum DocumentSyncManager {
         source.setCancelHandler { close(fd) }
         stageWatchers[stageID] = source
         source.resume()
-        let timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { _ in handler() }
+        let timer = Timer.scheduledTimer(withTimeInterval: syncInterval, repeats: true) { _ in handler() }
         stageTimers[stageID] = timer
         RunLoop.main.add(timer, forMode: .common)
     }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -93,3 +93,8 @@
 "sync_info_scrivener" = "Scrivener item %@\nin project:\n%@";
 "close" = "Close";
 "unlink" = "Unlink";
+"pause_sync" = "Pause sync";
+"pause_sync_all" = "Pause synchronization";
+"change" = "Change";
+"sync_interval_prefix" = "Check every";
+"sync_interval_suffix" = "seconds";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -93,3 +93,8 @@
 "sync_info_scrivener" = "Элемент Scrivener %@\nв проекте:\n%@";
 "close" = "Закрыть";
 "unlink" = "Отвязать";
+"pause_sync" = "Приостановить синхронизацию";
+"pause_sync_all" = "Приостановить синхронизацию";
+"change" = "Изменить";
+"sync_interval_prefix" = "Отслеживать изменения каждые";
+"sync_interval_suffix" = "секунд";

--- a/nfprogress/SettingsView.swift
+++ b/nfprogress/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @EnvironmentObject private var settings: AppSettings
+    @State private var intervalText: String = ""
     private let viewSpacing: CGFloat = scaledSpacing(2)
     /// "38" приблизительно соответствует прежней ширине 300pt,
     /// кратной шагу компоновки.
@@ -22,8 +23,24 @@ struct SettingsView: View {
             .pickerStyle(.segmented)
 
             Toggle("disable_launch_animations", isOn: $settings.disableLaunchAnimations)
+                .toggleStyle(.switch)
 
             Toggle("disable_all_animations", isOn: $settings.disableAllAnimations)
+                .toggleStyle(.switch)
+
+            Toggle("pause_sync_all", isOn: $settings.pauseAllSync)
+                .toggleStyle(.switch)
+
+            HStack {
+                Text(settings.localized("sync_interval_prefix"))
+                SelectAllIntField(text: $intervalText, placeholder: "interval")
+                    .frame(width: layoutStep(10))
+                Text(settings.localized("sync_interval_suffix"))
+            }
+            .onAppear { intervalText = String(Int(settings.syncInterval)) }
+            .onDisappear {
+                if let val = Double(intervalText) { settings.syncInterval = val }
+            }
 
             Spacer()
         }

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -30,6 +30,8 @@ class Stage: Identifiable {
     var lastScrivenerCharacters: Int?
     /// Последняя дата изменения Scrivener
     var lastScrivenerModified: Date?
+    /// Приостановлена ли синхронизация
+    var syncPaused: Bool = false
 
     init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int) {
         self.title = title
@@ -47,6 +49,7 @@ class Stage: Identifiable {
         self.lastWordModified = nil
         self.lastScrivenerCharacters = nil
         self.lastScrivenerModified = nil
+        self.syncPaused = false
     }
 
     /// Записи этого этапа без повторов

--- a/nfprogress/StageDocumentSyncInfoView.swift
+++ b/nfprogress/StageDocumentSyncInfoView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct StageDocumentSyncInfoView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
     @EnvironmentObject private var settings: AppSettings
     @Bindable var stage: Stage
 
@@ -33,6 +34,15 @@ struct StageDocumentSyncInfoView: View {
         VStack(spacing: scaledSpacing()) {
             Text(info)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            Toggle(settings.localized("pause_sync"), isOn: $stage.syncPaused)
+                .toggleStyle(.switch)
+                .onChange(of: stage.syncPaused) { value in
+                    if value { DocumentSyncManager.stopMonitoring(stage: stage) }
+                    else { DocumentSyncManager.startMonitoring(stage: stage) }
+                }
+            if stage.syncType == .scrivener {
+                Button(settings.localized("change")) { changeItem() }
+            }
             Spacer()
             HStack {
                 Spacer()
@@ -48,6 +58,14 @@ struct StageDocumentSyncInfoView: View {
 
     private func unlink() {
         DocumentSyncManager.removeSync(stage: stage)
+        dismiss()
+    }
+
+    private func changeItem() {
+        guard let basePath = DocumentSyncManager.resolvedPath(bookmark: stage.scrivenerProjectBookmark,
+                                                               path: stage.scrivenerProjectPath) else { return }
+        let request = StageScrivenerSelectRequest(stageID: stage.id, projectPath: basePath)
+        openWindow(id: "stageSelectScrivenerItem", value: request)
         dismiss()
     }
 }

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -25,6 +25,8 @@ class WritingProject {
     var scrivenerProjectBookmark: Data?
     /// Выбранный ID элемента Scrivener
     var scrivenerItemID: String?
+    /// Приостановлена ли синхронизация
+    var syncPaused: Bool = false
     /// Количество символов в файле при последней проверке
     var lastWordCharacters: Int?
     var lastScrivenerCharacters: Int?
@@ -40,6 +42,7 @@ class WritingProject {
         self.stages = []
         self.order = order
         self.isChartCollapsed = isChartCollapsed
+        self.syncPaused = false
     }
 
     /// Все записи проекта и этапов без повторов


### PR DESCRIPTION
## Summary
- allow adjusting sync interval and pausing sync globally
- support pausing sync per project/stage
- provide buttons to change Scrivener item in sync info windows
- add UI fields and translations for new settings
- use switch style for all sync toggles

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685c2c40bf0483338e6902271fa9dd87