### PR TITLE
Fix duplicate method definition in AppSettings

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -152,14 +152,6 @@ final class AppSettings: ObservableObject {
     }
 #endif
 
-#if os(macOS)
-    private func applyToolbarCustomization() {
-        for window in NSApplication.shared.windows {
-            window.toolbar?.allowsUserCustomization = allowToolbarCustomization
-        }
-    }
-#endif
-
     init(userDefaults: UserDefaults = .standard) {
         defaults = userDefaults
         disableLaunchAnimations = defaults.bool(forKey: "disableLaunchAnimations")
@@ -284,6 +276,14 @@ final class AppSettings {
     }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
+
+    #if os(macOS)
+    private func applyToolbarCustomization() {
+        for window in NSApplication.shared.windows {
+            window.toolbar?.allowsUserCustomization = allowToolbarCustomization
+        }
+    }
+    #endif
 
     init(userDefaults: UserDefaults = .standard) {
         defaults = userDefaults


### PR DESCRIPTION
## Summary
- remove repeated `applyToolbarCustomization` function
- add missing function for non-SwiftUI builds

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_685c46f0682c8333b0288fbc9bd26a38