### PR TITLE
Исправлен размер переключателя языка в настройках

### DIFF
--- a/nfprogress/SettingsView.swift
+++ b/nfprogress/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
                 }
                 .labelsHidden()
                 .pickerStyle(.menu)
+                .fixedSize()
             }
 
             Toggle("disable_launch_animations", isOn: $settings.disableLaunchAnimations)


### PR DESCRIPTION
## Изменения
- обновлён `SettingsView` — у выпадающего списка выбора языка добавлен модификатор `.fixedSize()`

## Проверка
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685c4c0b41448333903ac693d7bf9555