### PR TITLE
Fix toolbar customization

### DIFF
--- a/nfprogress/MainMenuCommands.swift
+++ b/nfprogress/MainMenuCommands.swift
@@ -2,6 +2,12 @@
 import SwiftUI
 
 struct MainMenuCommands: Commands {
+    @ObservedObject var settings: AppSettings
+
+    init(settings: AppSettings) {
+        self._settings = ObservedObject(wrappedValue: settings)
+    }
+
     var body: some Commands {
         // Дополнительные команды в стандартном меню File
         CommandGroup(after: .newItem) {
@@ -34,6 +40,17 @@ struct MainMenuCommands: Commands {
             }
             .keyboardShortcut("n", modifiers: [.command, .option])
         }
+
+#if os(macOS)
+        CommandGroup(after: .toolbar) {
+            Button("customize_toolbar") {
+                if let window = NSApplication.shared.keyWindow {
+                    window.toolbar?.runCustomizationPalette(nil)
+                }
+            }
+            .disabled(!settings.allowToolbarCustomization)
+        }
+#endif
 
     }
 }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "pause_sync_all" = "Pause synchronization";
 "sync_already_linked" = "This file is already linked to another project or stage";
 "toolbar_customization" = "Allow toolbar customization";
+"customize_toolbar" = "Customize Toolbar…";
 "change" = "Change";
 "sync_interval_prefix" = "Check every";
 "sync_interval_suffix" = "seconds";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "pause_sync_all" = "Приостановить синхронизацию";
 "sync_already_linked" = "Этот файл уже привязан к другому этапу или проекту";
 "toolbar_customization" = "Разрешить настройку панели";
+"customize_toolbar" = "Настроить панель инструментов…";
 "change" = "Изменить";
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -48,7 +48,9 @@ struct nfprogressApp: App {
 #endif
         }
         .modelContainer(DataController.shared)
-        .commands { MainMenuCommands() }
+        .commands {
+            MainMenuCommands(settings: settings)
+        }
         #if os(macOS)
         .onChange(of: settings.language) { newLang in
             Self.localizeMenus(language: newLang)


### PR DESCRIPTION
## Summary
- inject `AppSettings` via initializer to MainMenuCommands
- pass settings object through `.commands` builder
- keep toolbar button disabled unless customization enabled

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685cf3b2def48333b92e8db8e1eb94f6