### PR TITLE
Fix toolbar customization

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -147,7 +147,11 @@ final class AppSettings: ObservableObject {
 #if os(macOS)
     private func applyToolbarCustomization() {
         for window in NSApplication.shared.windows {
-            window.toolbar?.allowsUserCustomization = allowToolbarCustomization
+            guard let toolbar = window.toolbar else { continue }
+            if !allowToolbarCustomization && toolbar.customizationPaletteIsRunning {
+                toolbar.runCustomizationPalette(nil)
+            }
+            toolbar.allowsUserCustomization = allowToolbarCustomization
         }
     }
 #endif
@@ -280,7 +284,11 @@ final class AppSettings {
     #if os(macOS)
     private func applyToolbarCustomization() {
         for window in NSApplication.shared.windows {
-            window.toolbar?.allowsUserCustomization = allowToolbarCustomization
+            guard let toolbar = window.toolbar else { continue }
+            if !allowToolbarCustomization && toolbar.customizationPaletteIsRunning {
+                toolbar.runCustomizationPalette(nil)
+            }
+            toolbar.allowsUserCustomization = allowToolbarCustomization
         }
     }
     #endif

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -140,7 +140,11 @@ struct ContentView: View {
       }
       .listStyle(.plain)
       .navigationTitle("my_texts")
+#if os(macOS)
+      .toolbar(id: "mainToolbar") { toolbarContent }
+#else
       .toolbar { toolbarContent }
+#endif
     }, detail: {
       if let project = selectedProject {
         ProjectDetailView(project: project)
@@ -191,11 +195,13 @@ struct ContentView: View {
     if UIDevice.current.userInterfaceIdiom == .pad {
       ToolbarItem(placement: .navigationBarTrailing) {
         HStack {
-          Button(action: addProject) {
-            Label("add", systemImage: "plus")
-          }
-          .keyboardShortcut("N", modifiers: [.command, .shift])
-          .help(settings.localized("add_project_tooltip"))
+      ToolbarItem(id: "add") {
+        Button(action: addProject) {
+          Label("add", systemImage: "plus")
+        }
+        .keyboardShortcut("N", modifiers: [.command, .shift])
+        .help(settings.localized("add_project_tooltip"))
+      }
 
           if selectedProject != nil {
             Button(action: deleteSelectedProject) {
@@ -276,45 +282,57 @@ struct ContentView: View {
       }
     }
 #else
-    ToolbarItemGroup(placement: .automatic) {
-      Button(action: addProject) {
-        Label("add", systemImage: "plus")
+    ToolbarItemGroup(id: "projectActions", placement: .automatic) {
+      ToolbarItem(id: "add") {
+        Button(action: addProject) {
+          Label("add", systemImage: "plus")
+        }
+        .keyboardShortcut("N", modifiers: [.command, .shift])
+        .help(settings.localized("add_project_tooltip"))
       }
-      .keyboardShortcut("N", modifiers: [.command, .shift])
-      .help(settings.localized("add_project_tooltip"))
 
       if selectedProject != nil {
-        Button(action: deleteSelectedProject) {
-          Label("delete", systemImage: "minus")
+        ToolbarItem(id: "delete") {
+          Button(action: deleteSelectedProject) {
+            Label("delete", systemImage: "minus")
+          }
+          .keyboardShortcut(.return, modifiers: .command)
+          .help(settings.localized("delete_project_tooltip"))
         }
-        .keyboardShortcut(.return, modifiers: .command)
-        .help(settings.localized("delete_project_tooltip"))
       }
 
-      Button(action: importSelectedProject) {
-        Image(systemName: "square.and.arrow.down")
+      ToolbarItem(id: "import") {
+        Button(action: importSelectedProject) {
+          Image(systemName: "square.and.arrow.down")
+        }
+        .accessibilityLabel(settings.localized("import"))
+        .help(settings.localized("import_project_tooltip"))
       }
-      .accessibilityLabel(settings.localized("import"))
-      .help(settings.localized("import_project_tooltip"))
 
       if selectedProject != nil {
-        Button(action: exportSelectedProject) {
-          Image(systemName: "square.and.arrow.up")
+        ToolbarItem(id: "export") {
+          Button(action: exportSelectedProject) {
+            Image(systemName: "square.and.arrow.up")
+          }
+          .accessibilityLabel(settings.localized("export"))
+          .help(settings.localized("export_project_tooltip"))
         }
-        .accessibilityLabel(settings.localized("export"))
-        .help(settings.localized("export_project_tooltip"))
 
-        Button {
-          settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
-        } label: {
-          Image(systemName: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
+        ToolbarItem(id: "viewStyle") {
+          Button {
+            settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
+          } label: {
+            Image(systemName: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
+          }
+          .help(settings.localized("toggle_view_tooltip"))
         }
-        .help(settings.localized("toggle_view_tooltip"))
 
-        Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
-          Image(systemName: settings.projectSortOrder.iconName)
+        ToolbarItem(id: "sortOrder") {
+          Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
+            Image(systemName: settings.projectSortOrder.iconName)
+          }
+          .help(settings.localized("toggle_sort_tooltip"))
         }
-        .help(settings.localized("toggle_sort_tooltip"))
       }
     }
 #endif

--- a/nfprogress/MainMenuCommands.swift
+++ b/nfprogress/MainMenuCommands.swift
@@ -2,6 +2,12 @@
 import SwiftUI
 
 struct MainMenuCommands: Commands {
+    @ObservedObject var settings: AppSettings
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
+
     var body: some Commands {
         // Дополнительные команды в стандартном меню File
         CommandGroup(after: .newItem) {
@@ -34,6 +40,17 @@ struct MainMenuCommands: Commands {
             }
             .keyboardShortcut("n", modifiers: [.command, .option])
         }
+
+#if os(macOS)
+        CommandGroup(after: .toolbar) {
+            Button("customize_toolbar") {
+                if let window = NSApplication.shared.keyWindow {
+                    window.toolbar?.runCustomizationPalette(nil)
+                }
+            }
+            .disabled(!settings.allowToolbarCustomization)
+        }
+#endif
 
     }
 }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "pause_sync_all" = "Pause synchronization";
 "sync_already_linked" = "This file is already linked to another project or stage";
 "toolbar_customization" = "Allow toolbar customization";
+"customize_toolbar" = "Customize Toolbar…";
 "change" = "Change";
 "sync_interval_prefix" = "Check every";
 "sync_interval_suffix" = "seconds";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "pause_sync_all" = "Приостановить синхронизацию";
 "sync_already_linked" = "Этот файл уже привязан к другому этапу или проекту";
 "toolbar_customization" = "Разрешить настройку панели";
+"customize_toolbar" = "Настроить панель инструментов…";
 "change" = "Изменить";
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -48,7 +48,9 @@ struct nfprogressApp: App {
 #endif
         }
         .modelContainer(DataController.shared)
-        .commands { MainMenuCommands() }
+        .commands {
+            MainMenuCommands(settings: settings)
+        }
         #if os(macOS)
         .onChange(of: settings.language) { newLang in
             Self.localizeMenus(language: newLang)


### PR DESCRIPTION
## Summary
- use `@ObservedObject` for settings in main commands
- pass settings directly via initializer in `nfprogressApp`

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685cf3b2def48333b92e8db8e1eb94f6