### PR TITLE
Fix toolbar customization

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -145,9 +145,13 @@ final class AppSettings: ObservableObject {
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
 #if os(macOS)
-    private func applyToolbarCustomization() {
+    func applyToolbarCustomization() {
         for window in NSApplication.shared.windows {
-            window.toolbar?.allowsUserCustomization = allowToolbarCustomization
+            guard let toolbar = window.toolbar else { continue }
+            if !allowToolbarCustomization && toolbar.customizationPaletteIsRunning {
+                toolbar.runCustomizationPalette(nil)
+            }
+            toolbar.allowsUserCustomization = allowToolbarCustomization
         }
     }
 #endif
@@ -278,9 +282,13 @@ final class AppSettings {
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     #if os(macOS)
-    private func applyToolbarCustomization() {
+    func applyToolbarCustomization() {
         for window in NSApplication.shared.windows {
-            window.toolbar?.allowsUserCustomization = allowToolbarCustomization
+            guard let toolbar = window.toolbar else { continue }
+            if !allowToolbarCustomization && toolbar.customizationPaletteIsRunning {
+                toolbar.runCustomizationPalette(nil)
+            }
+            toolbar.allowsUserCustomization = allowToolbarCustomization
         }
     }
     #endif

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -140,7 +140,7 @@ struct ContentView: View {
       }
       .listStyle(.plain)
       .navigationTitle("my_texts")
-      .toolbar { toolbarContent }
+      .toolbar(id: "mainToolbar") { toolbarContent }
     }, detail: {
       if let project = selectedProject {
         ProjectDetailView(project: project)
@@ -185,6 +185,62 @@ struct ContentView: View {
     }
   }
 
+  #if os(macOS)
+  @ToolbarContentBuilder
+  private var toolbarContent: some CustomizableToolbarContent {
+    ToolbarItem(id: "add", placement: .automatic) {
+      Button(action: addProject) {
+        Label("add", systemImage: "plus")
+      }
+      .keyboardShortcut("N", modifiers: [.command, .shift])
+      .help(settings.localized("add_project_tooltip"))
+    }
+
+    if selectedProject != nil {
+      ToolbarItem(id: "delete", placement: .automatic) {
+        Button(action: deleteSelectedProject) {
+          Label("delete", systemImage: "minus")
+        }
+        .keyboardShortcut(.return, modifiers: .command)
+        .help(settings.localized("delete_project_tooltip"))
+      }
+    }
+
+    ToolbarItem(id: "import", placement: .automatic) {
+      Button(action: importSelectedProject) {
+        Image(systemName: "square.and.arrow.down")
+      }
+      .accessibilityLabel(settings.localized("import"))
+      .help(settings.localized("import_project_tooltip"))
+    }
+
+    if selectedProject != nil {
+      ToolbarItem(id: "export", placement: .automatic) {
+        Button(action: exportSelectedProject) {
+          Image(systemName: "square.and.arrow.up")
+        }
+        .accessibilityLabel(settings.localized("export"))
+        .help(settings.localized("export_project_tooltip"))
+      }
+
+      ToolbarItem(id: "toggleView", placement: .automatic) {
+        Button {
+          settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
+        } label: {
+          Image(systemName: settings.projectListStyle == .detailed ? "chart.pie" : "list.bullet")
+        }
+        .help(settings.localized("toggle_view_tooltip"))
+      }
+
+      ToolbarItem(id: "toggleSort", placement: .automatic) {
+        Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
+          Image(systemName: settings.projectSortOrder.iconName)
+        }
+        .help(settings.localized("toggle_sort_tooltip"))
+      }
+    }
+  }
+  #else
   @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
 #if os(iOS)
@@ -319,6 +375,7 @@ struct ContentView: View {
     }
 #endif
   }
+  #endif
 
   var body: some View {
     splitView
@@ -374,6 +431,7 @@ struct ContentView: View {
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)
+    .onAppear { settings.applyToolbarCustomization() }
 #endif
   }
 

--- a/nfprogress/MainMenuCommands.swift
+++ b/nfprogress/MainMenuCommands.swift
@@ -2,6 +2,12 @@
 import SwiftUI
 
 struct MainMenuCommands: Commands {
+    @ObservedObject var settings: AppSettings
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
+
     var body: some Commands {
         // Дополнительные команды в стандартном меню File
         CommandGroup(after: .newItem) {
@@ -34,6 +40,17 @@ struct MainMenuCommands: Commands {
             }
             .keyboardShortcut("n", modifiers: [.command, .option])
         }
+
+#if os(macOS)
+        CommandGroup(after: .toolbar) {
+            Button("customize_toolbar") {
+                if let window = NSApplication.shared.keyWindow {
+                    window.toolbar?.runCustomizationPalette(nil)
+                }
+            }
+            .disabled(!settings.allowToolbarCustomization)
+        }
+#endif
 
     }
 }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "pause_sync_all" = "Pause synchronization";
 "sync_already_linked" = "This file is already linked to another project or stage";
 "toolbar_customization" = "Allow toolbar customization";
+"customize_toolbar" = "Customize Toolbar…";
 "change" = "Change";
 "sync_interval_prefix" = "Check every";
 "sync_interval_suffix" = "seconds";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "pause_sync_all" = "Приостановить синхронизацию";
 "sync_already_linked" = "Этот файл уже привязан к другому этапу или проекту";
 "toolbar_customization" = "Разрешить настройку панели";
+"customize_toolbar" = "Настроить панель инструментов…";
 "change" = "Изменить";
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -48,7 +48,9 @@ struct nfprogressApp: App {
 #endif
         }
         .modelContainer(DataController.shared)
-        .commands { MainMenuCommands() }
+        .commands {
+            MainMenuCommands(settings: settings)
+        }
         #if os(macOS)
         .onChange(of: settings.language) { newLang in
             Self.localizeMenus(language: newLang)


### PR DESCRIPTION
## Summary
- expose `applyToolbarCustomization` so it can be called after window creation
- invoke customization setup when the main window appears

## Testing
- `swift test --disable-automatic-resolution`


------
https://chatgpt.com/codex/tasks/task_e_685cf3b2def48333b92e8db8e1eb94f6