### PR TITLE
Add toolbar customization updates

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -145,7 +145,7 @@ final class AppSettings: ObservableObject {
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
 #if os(macOS)
-    private func applyToolbarCustomization() {
+    func applyToolbarCustomization() {
         for window in NSApplication.shared.windows {
             guard let toolbar = window.toolbar else { continue }
             if !allowToolbarCustomization && toolbar.customizationPaletteIsRunning {
@@ -282,7 +282,7 @@ final class AppSettings {
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     #if os(macOS)
-    private func applyToolbarCustomization() {
+    func applyToolbarCustomization() {
         for window in NSApplication.shared.windows {
             guard let toolbar = window.toolbar else { continue }
             if !allowToolbarCustomization && toolbar.customizationPaletteIsRunning {

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -196,8 +196,8 @@ struct ContentView: View {
       .help(settings.localized("add_project_tooltip"))
     }
 
-    if selectedProject != nil {
-      ToolbarItem(id: "delete", placement: .automatic) {
+    ToolbarItem(id: "delete", placement: .automatic) {
+      if selectedProject != nil {
         Button(action: deleteSelectedProject) {
           Label("delete", systemImage: "minus")
         }
@@ -214,16 +214,18 @@ struct ContentView: View {
       .help(settings.localized("import_project_tooltip"))
     }
 
-    if selectedProject != nil {
-      ToolbarItem(id: "export", placement: .automatic) {
+    ToolbarItem(id: "export", placement: .automatic) {
+      if selectedProject != nil {
         Button(action: exportSelectedProject) {
           Image(systemName: "square.and.arrow.up")
         }
         .accessibilityLabel(settings.localized("export"))
         .help(settings.localized("export_project_tooltip"))
       }
+    }
 
-      ToolbarItem(id: "toggleView", placement: .automatic) {
+    ToolbarItem(id: "toggleView", placement: .automatic) {
+      if selectedProject != nil {
         Button {
           settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
         } label: {
@@ -231,8 +233,10 @@ struct ContentView: View {
         }
         .help(settings.localized("toggle_view_tooltip"))
       }
+    }
 
-      ToolbarItem(id: "toggleSort", placement: .automatic) {
+    ToolbarItem(id: "toggleSort", placement: .automatic) {
+      if selectedProject != nil {
         Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
           Image(systemName: settings.projectSortOrder.iconName)
         }
@@ -431,6 +435,10 @@ struct ContentView: View {
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)
+    .onAppear { settings.applyToolbarCustomization() }
+    .onChange(of: selectedProject) { _ in
+      settings.applyToolbarCustomization()
+    }
 #endif
   }
 

--- a/nfprogress/MainMenuCommands.swift
+++ b/nfprogress/MainMenuCommands.swift
@@ -44,6 +44,7 @@ struct MainMenuCommands: Commands {
 #if os(macOS)
         CommandGroup(after: .toolbar) {
             Button("customize_toolbar") {
+                settings.applyToolbarCustomization()
                 if let window = NSApplication.shared.keyWindow {
                     window.toolbar?.runCustomizationPalette(nil)
                 }


### PR DESCRIPTION
## Summary
- add public `applyToolbarCustomization` helper in `AppSettings`
- adjust macOS toolbar to hide delete and export buttons when nothing selected
- synchronize toolbar customization from main menu
- update ContentView to refresh toolbar when project selection changes

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685d0c21b4c08333b439f8dbdfdce768