### PR TITLE
Add custom project sort order

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -75,16 +75,24 @@ final class AppSettings: ObservableObject {
     enum ProjectSortOrder: String, CaseIterable, Identifiable {
         case title
         case progress
+        case custom
         var id: String { rawValue }
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     @Published var projectListStyle: ProjectListStyle {
@@ -214,15 +222,23 @@ final class AppSettings {
     enum ProjectSortOrder: String {
         case title
         case progress
+        case custom
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     var projectListStyle: ProjectListStyle {

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
   @State private var showingAddProject = false
   @State private var projectToDelete: WritingProject?
   @State private var showDeleteAlert = false
+  @State private var editMode: EditMode = .inactive
 #if os(macOS)
   @AppStorage("sidebarWidth") private var sidebarWidthRaw: Double = 405
   private var sidebarWidth: CGFloat {
@@ -50,6 +51,8 @@ struct ContentView: View {
       return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
       return projects.sorted { $0.progress > $1.progress }
+    case .custom:
+      return projects
     }
   }
 
@@ -71,6 +74,8 @@ struct ContentView: View {
               .listRowInsets(EdgeInsets())
               .buttonStyle(.plain)
             }
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
             .onDelete(perform: deleteProjects)
           }
           .listStyle(.plain)
@@ -109,6 +114,8 @@ struct ContentView: View {
               .listRowInsets(EdgeInsets())
               .listRowBackground(selectedProject === project ? Color.accentColor.opacity(0.1) : Color.clear)
             }
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
             .onDelete(perform: deleteProjects)
           }
           .listStyle(.plain)
@@ -136,6 +143,8 @@ struct ContentView: View {
           .listRowInsets(EdgeInsets())
           .buttonStyle(.plain)
         }
+        .onMove(perform: moveProjects)
+        .moveDisabled(settings.projectSortOrder != .custom)
         .onDelete(perform: deleteProjects)
       }
       .listStyle(.plain)
@@ -388,6 +397,7 @@ struct ContentView: View {
 
   var body: some View {
     splitView
+      .environment(\.editMode, $editMode)
       .fileExporter(
         isPresented: $isExporting,
         document: exportDocument,
@@ -436,6 +446,9 @@ struct ContentView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .menuExport)) { _ in
       exportSelectedProject()
+    }
+    .onChange(of: settings.projectSortOrder) { newValue in
+      editMode = newValue == .custom ? .active : .inactive
     }
 #if os(macOS)
     .onExitCommand { selectedProject = nil }


### PR DESCRIPTION
## Summary
- extend `ProjectSortOrder` with `custom` case and cycle logic
- support dragging projects when custom sort is active
- reflect new option in ContentView's sorting logic

## Testing
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685d435fd7408333abadfc730b86998b