### PR TITLE
Add custom sort option

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -75,16 +75,24 @@ final class AppSettings: ObservableObject {
     enum ProjectSortOrder: String, CaseIterable, Identifiable {
         case title
         case progress
+        case custom
         var id: String { rawValue }
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     @Published var projectListStyle: ProjectListStyle {
@@ -214,15 +222,23 @@ final class AppSettings {
     enum ProjectSortOrder: String {
         case title
         case progress
+        case custom
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     var projectListStyle: ProjectListStyle {

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -25,6 +25,9 @@ struct ContentView: View {
   @State private var showingAddProject = false
   @State private var projectToDelete: WritingProject?
   @State private var showDeleteAlert = false
+#if os(iOS)
+  @State private var editMode: EditMode = .inactive
+#endif
 #if os(macOS)
   @AppStorage("sidebarWidth") private var sidebarWidthRaw: Double = 405
   private var sidebarWidth: CGFloat {
@@ -50,6 +53,8 @@ struct ContentView: View {
       return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
       return projects.sorted { $0.progress > $1.progress }
+    case .custom:
+      return projects
     }
   }
 
@@ -71,6 +76,8 @@ struct ContentView: View {
               .listRowInsets(EdgeInsets())
               .buttonStyle(.plain)
             }
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
             .onDelete(perform: deleteProjects)
           }
           .listStyle(.plain)
@@ -109,6 +116,8 @@ struct ContentView: View {
               .listRowInsets(EdgeInsets())
               .listRowBackground(selectedProject === project ? Color.accentColor.opacity(0.1) : Color.clear)
             }
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
             .onDelete(perform: deleteProjects)
           }
           .listStyle(.plain)
@@ -136,6 +145,8 @@ struct ContentView: View {
           .listRowInsets(EdgeInsets())
           .buttonStyle(.plain)
         }
+        .onMove(perform: moveProjects)
+        .moveDisabled(settings.projectSortOrder != .custom)
         .onDelete(perform: deleteProjects)
       }
       .listStyle(.plain)
@@ -388,6 +399,9 @@ struct ContentView: View {
 
   var body: some View {
     splitView
+#if os(iOS)
+      .environment(\.editMode, $editMode)
+#endif
       .fileExporter(
         isPresented: $isExporting,
         document: exportDocument,
@@ -437,6 +451,11 @@ struct ContentView: View {
     .onReceive(NotificationCenter.default.publisher(for: .menuExport)) { _ in
       exportSelectedProject()
     }
+    #if os(iOS)
+    .onChange(of: settings.projectSortOrder) { newValue in
+      editMode = newValue == .custom ? .active : .inactive
+    }
+    #endif
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)


### PR DESCRIPTION
## Summary
- add `custom` option to `ProjectSortOrder`
- enable project dragging when custom sort is active
- restrict edit mode to iOS to avoid macOS build errors

## Testing
- `swift build`
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685d435fd7408333abadfc730b86998b