### PR TITLE
Add custom sort option

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -75,16 +75,24 @@ final class AppSettings: ObservableObject {
     enum ProjectSortOrder: String, CaseIterable, Identifiable {
         case title
         case progress
+        case custom
         var id: String { rawValue }
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     @Published var projectListStyle: ProjectListStyle {
@@ -214,15 +222,23 @@ final class AppSettings {
     enum ProjectSortOrder: String {
         case title
         case progress
+        case custom
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     var projectListStyle: ProjectListStyle {

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -25,6 +25,9 @@ struct ContentView: View {
   @State private var showingAddProject = false
   @State private var projectToDelete: WritingProject?
   @State private var showDeleteAlert = false
+#if os(iOS)
+  @State private var editMode: EditMode = .inactive
+#endif
 #if os(macOS)
   @AppStorage("sidebarWidth") private var sidebarWidthRaw: Double = 405
   private var sidebarWidth: CGFloat {
@@ -50,6 +53,8 @@ struct ContentView: View {
       return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
       return projects.sorted { $0.progress > $1.progress }
+    case .custom:
+      return projects
     }
   }
 
@@ -61,17 +66,17 @@ struct ContentView: View {
           List {
             let count = sortedProjects.count
             ForEach(Array(sortedProjects.enumerated()), id: \.element) { index, project in
-              Button(action: { selectedProject = project }) {
-                projectRow(for: project, index: index, totalCount: count)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .padding(.vertical, scaledSpacing(1))
-                  .frame(minHeight: circleHeight + layoutStep(2))
-                  .contentShape(Rectangle())
-              }
-              .listRowInsets(EdgeInsets())
-              .buttonStyle(.plain)
+              projectRow(for: project, index: index, totalCount: count)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, scaledSpacing(1))
+                .frame(minHeight: circleHeight + layoutStep(2))
+                .contentShape(Rectangle())
+                .onTapGesture { selectedProject = project }
+                .listRowInsets(EdgeInsets())
             }
             .onDelete(perform: deleteProjects)
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
           }
           .listStyle(.plain)
           .navigationTitle("my_texts")
@@ -92,24 +97,24 @@ struct ContentView: View {
           List {
             let count = sortedProjects.count
             ForEach(Array(sortedProjects.enumerated()), id: \.element) { index, project in
-              Button {
-                if selectedProject === project {
-                  openedProject = project
-                } else {
-                  selectedProject = project
+              projectRow(for: project, index: index, totalCount: count)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, scaledSpacing(1))
+                .frame(minHeight: (settings.projectListStyle == .detailed ? largeCircleHeight : circleHeight) + layoutStep(2))
+                .contentShape(Rectangle())
+                .onTapGesture {
+                  if selectedProject === project {
+                    openedProject = project
+                  } else {
+                    selectedProject = project
+                  }
                 }
-              } label: {
-                projectRow(for: project, index: index, totalCount: count)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .padding(.vertical, scaledSpacing(1))
-                  .frame(minHeight: (settings.projectListStyle == .detailed ? largeCircleHeight : circleHeight) + layoutStep(2))
-                  .contentShape(Rectangle())
-              }
-              .buttonStyle(.plain)
-              .listRowInsets(EdgeInsets())
-              .listRowBackground(selectedProject === project ? Color.accentColor.opacity(0.1) : Color.clear)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(selectedProject === project ? Color.accentColor.opacity(0.1) : Color.clear)
             }
             .onDelete(perform: deleteProjects)
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
           }
           .listStyle(.plain)
           .navigationTitle("my_texts")
@@ -126,17 +131,17 @@ struct ContentView: View {
       List {
         let count = sortedProjects.count
         ForEach(Array(sortedProjects.enumerated()), id: \.element) { index, project in
-          Button(action: { selectedProject = project }) {
-            projectRow(for: project, index: index, totalCount: count)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(.vertical, scaledSpacing(1))
-              .frame(minHeight: circleHeight + layoutStep(2))
-              .contentShape(Rectangle())
-          }
-          .listRowInsets(EdgeInsets())
-          .buttonStyle(.plain)
+          projectRow(for: project, index: index, totalCount: count)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, scaledSpacing(1))
+            .frame(minHeight: circleHeight + layoutStep(2))
+            .contentShape(Rectangle())
+            .onTapGesture { selectedProject = project }
+            .listRowInsets(EdgeInsets())
         }
         .onDelete(perform: deleteProjects)
+        .onMove(perform: moveProjects)
+        .moveDisabled(settings.projectSortOrder != .custom)
       }
       .listStyle(.plain)
       .navigationTitle("my_texts")
@@ -388,6 +393,9 @@ struct ContentView: View {
 
   var body: some View {
     splitView
+#if os(iOS)
+      .environment(\.editMode, $editMode)
+#endif
       .fileExporter(
         isPresented: $isExporting,
         document: exportDocument,
@@ -437,6 +445,11 @@ struct ContentView: View {
     .onReceive(NotificationCenter.default.publisher(for: .menuExport)) { _ in
       exportSelectedProject()
     }
+    #if os(iOS)
+    .onChange(of: settings.projectSortOrder) { newValue in
+      editMode = newValue == .custom ? .active : .inactive
+    }
+    #endif
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)


### PR DESCRIPTION
## Summary
- add `custom` option to `ProjectSortOrder`
- enable project dragging when custom sort is active
- restrict edit mode to iOS to avoid macOS build errors
- fix chained modifier order to resolve `onDelete` error
- make project rows tappable instead of buttons so drag to reorder works

## Testing
- `swift build`
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685d435fd7408333abadfc730b86998b