### PR TITLE
Enable drag sorting on macOS

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -75,16 +75,24 @@ final class AppSettings: ObservableObject {
     enum ProjectSortOrder: String, CaseIterable, Identifiable {
         case title
         case progress
+        case custom
         var id: String { rawValue }
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     @Published var projectListStyle: ProjectListStyle {
@@ -214,15 +222,23 @@ final class AppSettings {
     enum ProjectSortOrder: String {
         case title
         case progress
+        case custom
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .custom: return "arrow.up.arrow.down"
             }
         }
 
-        var next: ProjectSortOrder { self == .title ? .progress : .title }
+        var next: ProjectSortOrder {
+            switch self {
+            case .title: return .progress
+            case .progress: return .custom
+            case .custom: return .title
+            }
+        }
     }
 
     var projectListStyle: ProjectListStyle {

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -25,8 +25,12 @@ struct ContentView: View {
   @State private var showingAddProject = false
   @State private var projectToDelete: WritingProject?
   @State private var showDeleteAlert = false
+#if os(iOS)
+  @State private var editMode: EditMode = .inactive
+#endif
 #if os(macOS)
   @AppStorage("sidebarWidth") private var sidebarWidthRaw: Double = 405
+  @State private var draggedProject: WritingProject?
   private var sidebarWidth: CGFloat {
     get { CGFloat(sidebarWidthRaw) }
     nonmutating set { sidebarWidthRaw = Double(newValue) }
@@ -50,6 +54,8 @@ struct ContentView: View {
       return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
       return projects.sorted { $0.progress > $1.progress }
+    case .custom:
+      return projects
     }
   }
 
@@ -61,18 +67,21 @@ struct ContentView: View {
           List {
             let count = sortedProjects.count
             ForEach(Array(sortedProjects.enumerated()), id: \.element) { index, project in
-              Button(action: { selectedProject = project }) {
-                projectRow(for: project, index: index, totalCount: count)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .padding(.vertical, scaledSpacing(1))
-                  .frame(minHeight: circleHeight + layoutStep(2))
-                  .contentShape(Rectangle())
-              }
-              .listRowInsets(EdgeInsets())
-              .buttonStyle(.plain)
+              projectRow(for: project, index: index, totalCount: count)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, scaledSpacing(1))
+                .frame(minHeight: circleHeight + layoutStep(2))
+                .contentShape(Rectangle())
+                .onTapGesture { selectedProject = project }
+                .listRowInsets(EdgeInsets())
             }
             .onDelete(perform: deleteProjects)
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
           }
+#if os(iOS)
+          .environment(\.editMode, $editMode)
+#endif
           .listStyle(.plain)
           .navigationTitle("my_texts")
           .toolbar { toolbarContent }
@@ -92,25 +101,28 @@ struct ContentView: View {
           List {
             let count = sortedProjects.count
             ForEach(Array(sortedProjects.enumerated()), id: \.element) { index, project in
-              Button {
-                if selectedProject === project {
-                  openedProject = project
-                } else {
-                  selectedProject = project
+              projectRow(for: project, index: index, totalCount: count)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, scaledSpacing(1))
+                .frame(minHeight: (settings.projectListStyle == .detailed ? largeCircleHeight : circleHeight) + layoutStep(2))
+                .contentShape(Rectangle())
+                .onTapGesture {
+                  if selectedProject === project {
+                    openedProject = project
+                  } else {
+                    selectedProject = project
+                  }
                 }
-              } label: {
-                projectRow(for: project, index: index, totalCount: count)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .padding(.vertical, scaledSpacing(1))
-                  .frame(minHeight: (settings.projectListStyle == .detailed ? largeCircleHeight : circleHeight) + layoutStep(2))
-                  .contentShape(Rectangle())
-              }
-              .buttonStyle(.plain)
-              .listRowInsets(EdgeInsets())
-              .listRowBackground(selectedProject === project ? Color.accentColor.opacity(0.1) : Color.clear)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(selectedProject === project ? Color.accentColor.opacity(0.1) : Color.clear)
             }
             .onDelete(perform: deleteProjects)
+            .onMove(perform: moveProjects)
+            .moveDisabled(settings.projectSortOrder != .custom)
           }
+#if os(iOS)
+          .environment(\.editMode, $editMode)
+#endif
           .listStyle(.plain)
           .navigationTitle("my_texts")
           .navigationBarTitleDisplayMode(.inline)
@@ -126,17 +138,30 @@ struct ContentView: View {
       List {
         let count = sortedProjects.count
         ForEach(Array(sortedProjects.enumerated()), id: \.element) { index, project in
-          Button(action: { selectedProject = project }) {
-            projectRow(for: project, index: index, totalCount: count)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(.vertical, scaledSpacing(1))
-              .frame(minHeight: circleHeight + layoutStep(2))
-              .contentShape(Rectangle())
-          }
-          .listRowInsets(EdgeInsets())
-          .buttonStyle(.plain)
+          projectRow(for: project, index: index, totalCount: count)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, scaledSpacing(1))
+            .frame(minHeight: circleHeight + layoutStep(2))
+            .contentShape(Rectangle())
+            .onTapGesture { selectedProject = project }
+            .listRowInsets(EdgeInsets())
+#if os(macOS)
+            .onDrag {
+              draggedProject = project
+              return NSItemProvider(object: NSString(string: project.title))
+            }
+            .onDrop(of: [.text], delegate: ProjectDropDelegate(
+              target: project,
+              draggedItem: $draggedProject,
+              projects: sortedProjects,
+              moveAction: moveProjects,
+              isEnabled: settings.projectSortOrder == .custom
+            ))
+#endif
         }
         .onDelete(perform: deleteProjects)
+        .onMove(perform: moveProjects)
+        .moveDisabled(settings.projectSortOrder != .custom)
       }
       .listStyle(.plain)
       .navigationTitle("my_texts")
@@ -387,7 +412,12 @@ struct ContentView: View {
   #endif
 
   var body: some View {
+    #if os(iOS)
     splitView
+      .environment(\.editMode, $editMode)
+    #else
+    splitView
+    #endif
       .fileExporter(
         isPresented: $isExporting,
         document: exportDocument,
@@ -437,6 +467,11 @@ struct ContentView: View {
     .onReceive(NotificationCenter.default.publisher(for: .menuExport)) { _ in
       exportSelectedProject()
     }
+#if os(iOS)
+    .onChange(of: settings.projectSortOrder) { newValue in
+      editMode = newValue == .custom ? .active : .inactive
+    }
+#endif
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)
@@ -561,5 +596,29 @@ struct ContentView: View {
     }
     try? modelContext.save()
   }
+
+#if os(macOS)
+  private struct ProjectDropDelegate: DropDelegate {
+    let target: WritingProject
+    @Binding var draggedItem: WritingProject?
+    let projects: [WritingProject]
+    let moveAction: (IndexSet, Int) -> Void
+    let isEnabled: Bool
+
+    func dropEntered(info: DropInfo) {
+      guard isEnabled,
+            let dragged = draggedItem,
+            dragged != target,
+            let from = projects.firstIndex(of: dragged),
+            let to = projects.firstIndex(of: target) else { return }
+      moveAction(IndexSet(integer: from), to > from ? to + 1 : to)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+      draggedItem = nil
+      return isEnabled
+    }
+  }
+#endif
 }
 #endif


### PR DESCRIPTION
## Summary
- enable tracking of a dragged project on macOS
- implement custom drop delegate to reorder projects by drag
- attach drag and drop handlers when sort order is custom

## Testing
- `swift build`
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685d435fd7408333abadfc730b86998b