### PR TITLE
Исправлена логика ручной синхронизации

### DIFF
--- a/nfprogress/DocumentSyncManager.swift
+++ b/nfprogress/DocumentSyncManager.swift
@@ -182,6 +182,52 @@ enum DocumentSyncManager {
         return try? DataController.mainContext.fetch(descriptor).first
     }
 
+    /// Выполняет синхронизацию проекта один раз независимо от состояния паузы.
+    /// Периодическая синхронизация не возобновляется автоматически.
+    static func syncNow(project: WritingProject) {
+        guard let type = project.syncType else { return }
+        let id = project.id
+        switch type {
+        case .word:
+            if let url = resolveURL(bookmark: &project.wordFileBookmark,
+                                   path: project.wordFilePath) {
+                url.startAccessingSecurityScopedResource()
+                defer { url.stopAccessingSecurityScopedResource() }
+                checkWordFile(for: id)
+            }
+        case .scrivener:
+            if let base = resolveURL(bookmark: &project.scrivenerProjectBookmark,
+                                     path: project.scrivenerProjectPath) {
+                base.startAccessingSecurityScopedResource()
+                defer { base.stopAccessingSecurityScopedResource() }
+                checkScrivenerFile(for: id)
+            }
+        }
+    }
+
+    /// Выполняет синхронизацию этапа один раз независимо от состояния паузы.
+    /// Периодическая синхронизация не возобновляется автоматически.
+    static func syncNow(stage: Stage) {
+        guard let type = stage.syncType else { return }
+        let id = stage.id
+        switch type {
+        case .word:
+            if let url = resolveURL(bookmark: &stage.wordFileBookmark,
+                                   path: stage.wordFilePath) {
+                url.startAccessingSecurityScopedResource()
+                defer { url.stopAccessingSecurityScopedResource() }
+                checkWordFile(stageID: id)
+            }
+        case .scrivener:
+            if let base = resolveURL(bookmark: &stage.scrivenerProjectBookmark,
+                                     path: stage.scrivenerProjectPath) {
+                base.startAccessingSecurityScopedResource()
+                defer { base.stopAccessingSecurityScopedResource() }
+                checkScrivenerFile(stageID: id)
+            }
+        }
+    }
+
     static func startMonitoring(project: WritingProject) {
         stopMonitoring(project: project)
         guard !globallyPaused, !project.syncPaused, let type = project.syncType else { return }

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -159,6 +159,10 @@ struct ProjectDetailView: View {
             VStack(alignment: .leading) {
                 HStack {
                     Button("add_entry_button") { addEntryAction(stage) }
+                    Button("sync_now_button") {
+                        DocumentSyncManager.syncNow(stage: stage)
+                    }
+                    .disabled(stage.syncType == nil)
                     Spacer()
                 }
                 ForEach(stage.sortedEntries) { entry in
@@ -252,8 +256,15 @@ struct ProjectDetailView: View {
         Text("entries_history")
             .font(.title3.bold())
         if project.stages.isEmpty {
-            Button("add_entry_button") { addEntry() }
-                .keyboardShortcut("n", modifiers: .command)
+            HStack {
+                Button("add_entry_button") { addEntry() }
+                    .keyboardShortcut("n", modifiers: .command)
+                Button("sync_now_button") {
+                    DocumentSyncManager.syncNow(project: project)
+                }
+                .disabled(project.syncType == nil)
+                Spacer()
+            }
         }
         ForEach(project.sortedEntries) { entry in
             historyEntryRow(entry: entry)

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -100,3 +100,4 @@
 "change" = "Change";
 "sync_interval_prefix" = "Check every";
 "sync_interval_suffix" = "seconds";
+"sync_now_button" = "Synchronize";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -100,3 +100,4 @@
 "change" = "Изменить";
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";
+"sync_now_button" = "Синхронизация";


### PR DESCRIPTION
## Summary
- убрано автоматическое возобновление наблюдения после вызова `syncNow`
- при ручной синхронизации файлы открываются через `startAccessingSecurityScopedResource`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685db136b1108333b3678c96ca29b7af