### PR TITLE
Add progress delta to share preview

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -123,6 +123,14 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(lastShareTitleOffset, forKey: "lastShareTitleOffset") }
     }
 
+    @Published var lastShareProgress: [String: Int] {
+        didSet {
+            if let data = try? JSONEncoder().encode(lastShareProgress) {
+                defaults.set(data, forKey: "lastShareProgress")
+            }
+        }
+    }
+
     @Published var syncInterval: Double {
         didSet {
             defaults.set(syncInterval, forKey: "syncInterval")
@@ -187,6 +195,12 @@ final class AppSettings: ObservableObject {
         lastShareSpacing = s == 0 ? defaultShareSpacing : s
         let o = defaults.double(forKey: "lastShareTitleOffset")
         lastShareTitleOffset = o == 0 ? defaultShareTitleOffset : o
+        if let data = defaults.data(forKey: "lastShareProgress"),
+           let saved = try? JSONDecoder().decode([String: Int].self, from: data) {
+            lastShareProgress = saved
+        } else {
+            lastShareProgress = [:]
+        }
         let i = defaults.double(forKey: "syncInterval")
         syncInterval = i == 0 ? 2 : i
         pauseAllSync = defaults.bool(forKey: "pauseAllSync")
@@ -268,6 +282,13 @@ final class AppSettings {
     var lastShareTitleOffset: Double {
         didSet { defaults.set(lastShareTitleOffset, forKey: "lastShareTitleOffset") }
     }
+    var lastShareProgress: [String: Int] {
+        didSet {
+            if let data = try? JSONEncoder().encode(lastShareProgress) {
+                defaults.set(data, forKey: "lastShareProgress")
+            }
+        }
+    }
 
     var syncInterval: Double {
         didSet {
@@ -333,6 +354,12 @@ final class AppSettings {
         lastShareSpacing = s == 0 ? defaultShareSpacing : s
         let o = defaults.double(forKey: "lastShareTitleOffset")
         lastShareTitleOffset = o == 0 ? defaultShareTitleOffset : o
+        if let data = defaults.data(forKey: "lastShareProgress"),
+           let saved = try? JSONDecoder().decode([String: Int].self, from: data) {
+            lastShareProgress = saved
+        } else {
+            lastShareProgress = [:]
+        }
         let i = defaults.double(forKey: "syncInterval")
         syncInterval = i == 0 ? 2 : i
         pauseAllSync = defaults.bool(forKey: "pauseAllSync")

--- a/nfprogress/Color+Interpolate.swift
+++ b/nfprogress/Color+Interpolate.swift
@@ -44,6 +44,15 @@ extension Color {
                      brightness: bri,
                      opacity: alpha)
     }
+
+    /// Увеличивает яркость цвета на указанный коэффициент.
+    func brightened(by factor: Double) -> Color {
+        let c = components()
+        return Color(hue: c.h,
+                     saturation: c.s,
+                     brightness: min(c.b * factor, 1),
+                     opacity: c.a)
+    }
 }
 #else
 public struct Color: Equatable, Sendable {
@@ -80,6 +89,13 @@ public struct Color: Equatable, Sendable {
                      saturation: sat,
                      brightness: bri,
                      opacity: alpha)
+    }
+
+    /// Увеличивает яркость цвета на указанный коэффициент.
+    public func brightened(by factor: Double) -> Color {
+        var result = self
+        result.brightness = min(result.brightness * factor, 1)
+        return result
     }
 }
 #endif

--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -19,6 +19,7 @@ struct ProgressSharePreview: View {
     @State private var titleFontPercent: Double = 100
     @State private var spacingPercent: Double = 100
     @State private var offsetPercent: Double = 0
+    @State private var showDelta = false
     @State private var initialized = false
 #if os(iOS)
     @State private var shareURL: URL?
@@ -69,12 +70,14 @@ struct ProgressSharePreview: View {
             VStack(spacing: scaledSpacing(1.5)) {
                 Spacer()
                 ProgressShareView(project: project,
+                                   showDelta: showDelta,
                                    circleSize: circleSize,
                                    ringWidth: ringWidth,
                                    percentFontSize: percentSize,
                                    titleFontSize: titleSize,
                                    titleSpacing: spacing,
                                    titleOffset: titleOffset)
+                    .environmentObject(settings)
                     .scaleEffect(orientationScale)
                     .frame(width: shareImageSize * orientationScale,
                            height: shareImageSize * orientationScale)
@@ -89,6 +92,11 @@ struct ProgressSharePreview: View {
                     controlRow(title: settings.localized("share_preview_percent_size"), value: $percentFontPercent)
                     controlRow(title: settings.localized("share_preview_title_size"), value: $titleFontPercent)
                     controlRow(title: settings.localized("share_preview_spacing"), value: $spacingPercent)
+                    if showDelta {
+                        Button(settings.localized("share_mode_now")) { showDelta = false }
+                    } else {
+                        Button(settings.localized("share_mode_progress")) { showDelta = true }
+                    }
                 }
                 Spacer()
             }
@@ -136,12 +144,14 @@ struct ProgressSharePreview: View {
                 VStack {
                     Spacer()
                    if let img = progressShareImage(for: project,
-                                                  circleSize: circleSize,
-                                                  ringWidth: ringWidth,
-                                                  percentFontSize: percentSize,
-                                                  titleFontSize: titleSize,
-                                                  titleSpacing: spacing,
-                                                  titleOffset: titleOffset) {
+                                                 circleSize: circleSize,
+                                                 ringWidth: ringWidth,
+                                                 percentFontSize: percentSize,
+                                                 titleFontSize: titleSize,
+                                                 titleSpacing: spacing,
+                                                 titleOffset: titleOffset,
+                                                 showDelta: showDelta,
+                                                 settings: settings) {
                         Image(osImage: img)
                             .resizable()
                             .interpolation(.high)
@@ -169,7 +179,9 @@ struct ProgressSharePreview: View {
                                          percentFontSize: percentSize,
                                          titleFontSize: titleSize,
                                          titleSpacing: spacing,
-                                         titleOffset: titleOffset) else { return }
+                                         titleOffset: titleOffset,
+                                         showDelta: showDelta,
+                                         settings: settings) else { return }
         saveShareParams()
 #if os(iOS)
         shareURL = url
@@ -191,7 +203,9 @@ struct ProgressSharePreview: View {
                                              percentFontSize: percentSize,
                                              titleFontSize: titleSize,
                                              titleSpacing: spacing,
-                                             titleOffset: titleOffset) else { return }
+                                             titleOffset: titleOffset,
+                                             showDelta: showDelta,
+                                             settings: settings) else { return }
         saveShareParams()
 #if os(iOS)
         UIPasteboard.general.image = image
@@ -210,6 +224,8 @@ struct ProgressSharePreview: View {
         settings.lastShareTitleSize = Double(titleSize)
         settings.lastShareSpacing = Double(spacing)
         settings.lastShareTitleOffset = Double(titleOffset)
+        let key = String(describing: project.id)
+        settings.lastShareProgress[key] = project.currentProgress
     }
 
     @ViewBuilder

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "share_preview_percent_size" = "Percent size";
 "share_preview_title_size" = "Title size";
 "share_preview_spacing" = "Title spacing";
+"share_mode_progress" = "Progress";
+"share_mode_now" = "Now";
 "charts_framework_required" = "Charts framework is required";
 "scrivener_parse_error" = "Failed to load Scrivener project";
 "sync_info_word" = "Word file:\n%@";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "share_preview_percent_size" = "Размер процентов";
 "share_preview_title_size" = "Размер названия";
 "share_preview_spacing" = "Расстояние";
+"share_mode_progress" = "Прогресс";
+"share_mode_now" = "Сейчас";
 "charts_framework_required" = "Для отображения графика требуется фреймворк Charts";
 "scrivener_parse_error" = "Не удалось загрузить проект Scrivener";
 "sync_info_word" = "Файл Word:\n%@";


### PR DESCRIPTION
## Summary
- visualize previous share progress on share chart
- draw progress delta in a brighter color
- store last shared progress per project
- update share image helpers to inject settings

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685dd42f3fbc83339bb9dc61cac0e8a0