### PR TITLE
Add resizing persistence to share preview

### DIFF
--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -104,7 +104,7 @@ struct ProgressSharePreview: View {
         }
         .scaledPadding()
         #if os(macOS)
-        .frame(width: 560, height: 730)
+        .frame(minWidth: 560, minHeight: 730)
         .toolbar {
             ToolbarItemGroup { bottomControls }
         }

--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -141,6 +141,8 @@ extension nfprogressApp {
                     .environment(\.locale, settings.locale)
 #if os(macOS)
                     .windowTitle(settings.localized("share"))
+                    .persistentWindowFrame(id: "sharePreview")
+                    .persistentWindowSize(id: "sharePreview")
                     .windowDefaultSize(width: 560, height: 730)
 #endif
             }


### PR DESCRIPTION
## Summary
- allow resizing share preview window and restore its size

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685dde2be34c8333a4c2d9a19534ae70