### PR TITLE
Fix share preview now mode uses current progress

### DIFF
--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -43,7 +43,14 @@ private struct ProgressCircleSnapshotView: View {
         return min(max(Double(diff) / Double(project.goal), 0), 1)
     }
 
-    private var progressFraction: Double { previousFraction + deltaFraction }
+    private var currentFraction: Double {
+        guard project.goal > 0 else { return 0 }
+        return min(max(Double(project.currentProgress) / Double(project.goal), 0), 1)
+    }
+
+    private var progressFraction: Double {
+        showDelta ? previousFraction + deltaFraction : currentFraction
+    }
 
     private var baseColor: Color { .interpolate(from: .red, to: .green, fraction: progressFraction) }
     private var previousColor: Color { baseColor.opacity(0.4) }


### PR DESCRIPTION
## Summary
- fix progress share preview to use latest progress when 'Now' mode is selected

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685de06d6e308333b0b46597016be97d