### PR TITLE
Fix deadline reminders integration

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -158,6 +158,24 @@ final class AppSettings: ObservableObject {
         }
     }
 
+    @Published var deadlineReminders: Bool {
+        didSet {
+            defaults.set(deadlineReminders, forKey: "deadlineReminders")
+#if canImport(UserNotifications) && canImport(SwiftData)
+            DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+#endif
+        }
+    }
+
+    @Published var reminderTime: Date {
+        didSet {
+            defaults.set(reminderTime, forKey: "reminderTime")
+#if canImport(UserNotifications) && canImport(SwiftData)
+            DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+#endif
+        }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
 #if os(macOS)
@@ -206,6 +224,12 @@ final class AppSettings: ObservableObject {
         pauseAllSync = defaults.bool(forKey: "pauseAllSync")
         let allow = defaults.object(forKey: "allowToolbarCustomization") as? Bool ?? true
         allowToolbarCustomization = allow
+        deadlineReminders = defaults.bool(forKey: "deadlineReminders")
+        let defaultTime = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
+        reminderTime = defaults.object(forKey: "reminderTime") as? Date ?? defaultTime
+        #if canImport(UserNotifications) && canImport(SwiftData)
+        DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+        #endif
 #if os(macOS)
         applyToolbarCustomization()
 #endif
@@ -317,6 +341,24 @@ final class AppSettings {
         }
     }
 
+    var deadlineReminders: Bool {
+        didSet {
+            defaults.set(deadlineReminders, forKey: "deadlineReminders")
+            #if canImport(UserNotifications) && canImport(SwiftData)
+            DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+            #endif
+        }
+    }
+
+    var reminderTime: Date {
+        didSet {
+            defaults.set(reminderTime, forKey: "reminderTime")
+            #if canImport(UserNotifications) && canImport(SwiftData)
+            DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+            #endif
+        }
+    }
+
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
 
     #if os(macOS)
@@ -365,6 +407,12 @@ final class AppSettings {
         pauseAllSync = defaults.bool(forKey: "pauseAllSync")
         let allow = defaults.object(forKey: "allowToolbarCustomization") as? Bool ?? true
         allowToolbarCustomization = allow
+        deadlineReminders = defaults.bool(forKey: "deadlineReminders")
+        let defaultTime = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
+        reminderTime = defaults.object(forKey: "reminderTime") as? Date ?? defaultTime
+        #if canImport(UserNotifications) && canImport(SwiftData)
+        DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+        #endif
 #if os(macOS)
         applyToolbarCustomization()
 #endif

--- a/nfprogress/DeadlineReminderManager.swift
+++ b/nfprogress/DeadlineReminderManager.swift
@@ -1,0 +1,52 @@
+#if canImport(UserNotifications) && canImport(SwiftData)
+import Foundation
+import UserNotifications
+import SwiftData
+
+@MainActor
+enum DeadlineReminderManager {
+    private static var enabled: Bool = false
+    private static var time: Date = .now
+
+    static func updateSettings(enabled: Bool, time: Date) {
+        self.enabled = enabled
+        self.time = time
+        scheduleReminders()
+    }
+
+    static func scheduleReminders() {
+        let center = UNUserNotificationCenter.current()
+        center.removeAllPendingNotificationRequests()
+        guard enabled else { return }
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            schedule(for: center)
+        }
+    }
+
+    private static func schedule(for center: UNUserNotificationCenter) {
+        let context = DataController.mainContext
+        let descriptor = FetchDescriptor<WritingProject>()
+        if let projects = try? context.fetch(descriptor) {
+            for project in projects {
+                guard project.deadline != nil,
+                      let target = project.dailyTarget,
+                      project.goal > project.currentProgress else { continue }
+                var comps = DateComponents()
+                let t = Calendar.current.dateComponents([.hour, .minute], from: time)
+                comps.hour = t.hour
+                comps.minute = t.minute
+                comps.timeZone = Calendar.current.timeZone
+                let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: true)
+                let content = UNMutableNotificationContent()
+                content.title = project.title
+                content.body = String(format: NSLocalizedString("deadline_reminder_body", comment: ""), target)
+                content.sound = .default
+                let identifier = String(describing: project.id)
+                let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+                center.add(request)
+            }
+        }
+    }
+}
+#endif

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -104,3 +104,6 @@
 "sync_interval_prefix" = "Check every";
 "sync_interval_suffix" = "seconds";
 "sync_now_button" = "Synchronize";
+"deadline_reminders" = "Deadline reminders";
+"reminder_time" = "Notification time";
+"deadline_reminder_body" = "Shall we keep moving toward the goal? Only %d characters to write!";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -104,3 +104,6 @@
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";
 "sync_now_button" = "Синхронизация";
+"deadline_reminders" = "Напоминания о дедлайнах";
+"reminder_time" = "Время отправки";
+"deadline_reminder_body" = "Продолжим путь к цели? Надо написать всего %d символов!";

--- a/nfprogress/SettingsView.swift
+++ b/nfprogress/SettingsView.swift
@@ -61,6 +61,21 @@ struct SettingsView: View {
                 if let val = Double(intervalText) { settings.syncInterval = val }
             }
 
+            Toggle(isOn: $settings.deadlineReminders) {
+                Text("deadline_reminders")
+                    .frame(width: labelWidth, alignment: .leading)
+            }
+            .toggleStyle(.switch)
+
+            if settings.deadlineReminders {
+                HStack {
+                    Text("reminder_time")
+                        .frame(width: labelWidth, alignment: .leading)
+                    DatePicker("", selection: $settings.reminderTime, displayedComponents: .hourAndMinute)
+                        .labelsHidden()
+                }
+            }
+
             Spacer()
         }
         .scaledPadding()

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -31,6 +31,9 @@ struct nfprogressApp: App {
             }
         }
 #endif
+#if canImport(UserNotifications) && canImport(SwiftData)
+        DeadlineReminderManager.scheduleReminders()
+#endif
     }
     /// Глобальные настройки приложения, доступные во всех сценах
     @StateObject var settings = AppSettings()


### PR DESCRIPTION
## Summary
- guard reminder update code by notification & SwiftData availability
- include current timezone when scheduling reminders
- schedule reminders only if modules are present

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_685de68dad7c83338eff1ddaf84d0fe0