### PR TITLE
Добавлен переключатель напоминаний при запуске

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -164,6 +164,14 @@ final class AppSettings: ObservableObject {
 #if canImport(UserNotifications) && canImport(SwiftData)
             DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
 #endif
+            if deadlineReminders && !remindersOnLaunch {
+                remindersOnLaunch = true
+            }
+#if canImport(UserNotifications) && canImport(SwiftData)
+            if deadlineReminders && remindersOnLaunch {
+                DeadlineReminderManager.sendMissedRemindersIfNeeded()
+            }
+#endif
         }
     }
 
@@ -174,6 +182,10 @@ final class AppSettings: ObservableObject {
             DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
 #endif
         }
+    }
+
+    @Published var remindersOnLaunch: Bool {
+        didSet { defaults.set(remindersOnLaunch, forKey: "remindersOnLaunch") }
     }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
@@ -225,10 +237,15 @@ final class AppSettings: ObservableObject {
         let allow = defaults.object(forKey: "allowToolbarCustomization") as? Bool ?? true
         allowToolbarCustomization = allow
         deadlineReminders = defaults.bool(forKey: "deadlineReminders")
+        let launchDefault = defaults.object(forKey: "remindersOnLaunch") as? Bool ?? true
+        remindersOnLaunch = launchDefault
         let defaultTime = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
         reminderTime = defaults.object(forKey: "reminderTime") as? Date ?? defaultTime
         #if canImport(UserNotifications) && canImport(SwiftData)
         DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+        if deadlineReminders && remindersOnLaunch {
+            DeadlineReminderManager.sendMissedRemindersIfNeeded()
+        }
         #endif
 #if os(macOS)
         applyToolbarCustomization()
@@ -347,6 +364,14 @@ final class AppSettings {
             #if canImport(UserNotifications) && canImport(SwiftData)
             DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
             #endif
+            if deadlineReminders && !remindersOnLaunch {
+                remindersOnLaunch = true
+            }
+            #if canImport(UserNotifications) && canImport(SwiftData)
+            if deadlineReminders && remindersOnLaunch {
+                DeadlineReminderManager.sendMissedRemindersIfNeeded()
+            }
+            #endif
         }
     }
 
@@ -357,6 +382,10 @@ final class AppSettings {
             DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
             #endif
         }
+    }
+
+    var remindersOnLaunch: Bool {
+        didSet { defaults.set(remindersOnLaunch, forKey: "remindersOnLaunch") }
     }
 
     var locale: Locale { Locale(identifier: language.resolvedIdentifier) }
@@ -408,10 +437,15 @@ final class AppSettings {
         let allow = defaults.object(forKey: "allowToolbarCustomization") as? Bool ?? true
         allowToolbarCustomization = allow
         deadlineReminders = defaults.bool(forKey: "deadlineReminders")
+        let launchDefault = defaults.object(forKey: "remindersOnLaunch") as? Bool ?? true
+        remindersOnLaunch = launchDefault
         let defaultTime = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: Date())!
         reminderTime = defaults.object(forKey: "reminderTime") as? Date ?? defaultTime
         #if canImport(UserNotifications) && canImport(SwiftData)
         DeadlineReminderManager.updateSettings(enabled: deadlineReminders, time: reminderTime)
+        if deadlineReminders && remindersOnLaunch {
+            DeadlineReminderManager.sendMissedRemindersIfNeeded()
+        }
         #endif
 #if os(macOS)
         applyToolbarCustomization()

--- a/nfprogress/DeadlineReminderManager.swift
+++ b/nfprogress/DeadlineReminderManager.swift
@@ -24,6 +24,22 @@ enum DeadlineReminderManager {
         }
     }
 
+    static func sendMissedRemindersIfNeeded() {
+        let center = UNUserNotificationCenter.current()
+        guard enabled else { return }
+        let calendar = Calendar.current
+        let comps = calendar.dateComponents([.hour, .minute], from: time)
+        guard let scheduled = calendar.date(bySettingHour: comps.hour ?? 0,
+                                            minute: comps.minute ?? 0,
+                                            second: 0,
+                                            of: Date()) else { return }
+        guard Date() > scheduled else { return }
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            deliverNow(for: center)
+        }
+    }
+
     private static func schedule(for center: UNUserNotificationCenter) {
         let context = DataController.mainContext
         let descriptor = FetchDescriptor<WritingProject>()
@@ -44,6 +60,26 @@ enum DeadlineReminderManager {
                 content.sound = .default
                 let identifier = String(describing: project.id)
                 let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+                center.add(request)
+            }
+        }
+    }
+
+    private static func deliverNow(for center: UNUserNotificationCenter) {
+        let context = DataController.mainContext
+        let descriptor = FetchDescriptor<WritingProject>()
+        if let projects = try? context.fetch(descriptor) {
+            for project in projects {
+                guard project.deadline != nil,
+                      let target = project.dailyTarget,
+                      project.goal > project.currentProgress else { continue }
+                let content = UNMutableNotificationContent()
+                content.title = project.title
+                content.body = String(format: NSLocalizedString("deadline_reminder_body", comment: ""), target)
+                content.sound = .default
+                let request = UNNotificationRequest(identifier: UUID().uuidString,
+                                                   content: content,
+                                                   trigger: nil)
                 center.add(request)
             }
         }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -106,4 +106,5 @@
 "sync_now_button" = "Synchronize";
 "deadline_reminders" = "Deadline reminders";
 "reminder_time" = "Notification time";
+"reminders_on_launch" = "Send reminders on launch";
 "deadline_reminder_body" = "Shall we keep moving toward the goal? Only %d characters to write!";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -106,4 +106,5 @@
 "sync_now_button" = "Синхронизация";
 "deadline_reminders" = "Напоминания о дедлайнах";
 "reminder_time" = "Время отправки";
+"reminders_on_launch" = "Присылать напоминания при запуске";
 "deadline_reminder_body" = "Продолжим путь к цели? Надо написать всего %d символов!";

--- a/nfprogress/SettingsView.swift
+++ b/nfprogress/SettingsView.swift
@@ -74,6 +74,12 @@ struct SettingsView: View {
                     DatePicker("", selection: $settings.reminderTime, displayedComponents: .hourAndMinute)
                         .labelsHidden()
                 }
+
+                Toggle(isOn: $settings.remindersOnLaunch) {
+                    Text("reminders_on_launch")
+                        .frame(width: labelWidth, alignment: .leading)
+                }
+                .toggleStyle(.switch)
             }
 
             Spacer()


### PR DESCRIPTION
## Summary
- добавлен параметр `remindersOnLaunch` в `AppSettings`
- реализована проверка и отправка пропущенных напоминаний в `DeadlineReminderManager`
- добавлен переключатель в `SettingsView`
- обновлены локализации для английского и русского языков

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_685df16ceda48333a765f0c65545aef6