### PR TITLE
Add deadline sort option

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -75,6 +75,7 @@ final class AppSettings: ObservableObject {
     enum ProjectSortOrder: String, CaseIterable, Identifiable {
         case title
         case progress
+        case deadline
         case custom
         var id: String { rawValue }
 
@@ -82,6 +83,7 @@ final class AppSettings: ObservableObject {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
             }
         }
@@ -89,7 +91,8 @@ final class AppSettings: ObservableObject {
         var next: ProjectSortOrder {
             switch self {
             case .title: return .progress
-            case .progress: return .custom
+            case .progress: return .deadline
+            case .deadline: return .custom
             case .custom: return .title
             }
         }
@@ -277,12 +280,14 @@ final class AppSettings {
     enum ProjectSortOrder: String {
         case title
         case progress
+        case deadline
         case custom
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
             }
         }
@@ -290,7 +295,8 @@ final class AppSettings {
         var next: ProjectSortOrder {
             switch self {
             case .title: return .progress
-            case .progress: return .custom
+            case .progress: return .deadline
+            case .deadline: return .custom
             case .custom: return .title
             }
         }

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -54,6 +54,12 @@ struct ContentView: View {
       return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
       return projects.sorted { $0.progress > $1.progress }
+    case .deadline:
+      return projects.sorted {
+        let d0 = $0.deadline == nil ? Int.max : $0.daysLeft
+        let d1 = $1.deadline == nil ? Int.max : $1.daysLeft
+        return d0 < d1
+      }
     case .custom:
       return projects
     }


### PR DESCRIPTION
## Summary
- allow sorting projects by their deadlines
- add UI cycle and icon for deadline sort order

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685df67871f08333b5ac083ffcd271db