### PR TITLE
Add deadline sort option

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -75,13 +75,25 @@ final class AppSettings: ObservableObject {
     enum ProjectSortOrder: String, CaseIterable, Identifiable {
         case title
         case progress
+        case deadline
         case custom
         var id: String { rawValue }
+#if canImport(SwiftUI)
+        var description: LocalizedStringKey {
+            switch self {
+            case .title: return "sort_title"
+            case .progress: return "sort_progress"
+            case .deadline: return "sort_deadline"
+            case .custom: return "sort_custom"
+            }
+        }
+#endif
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
             }
         }
@@ -89,7 +101,8 @@ final class AppSettings: ObservableObject {
         var next: ProjectSortOrder {
             switch self {
             case .title: return .progress
-            case .progress: return .custom
+            case .progress: return .deadline
+            case .deadline: return .custom
             case .custom: return .title
             }
         }
@@ -277,12 +290,23 @@ final class AppSettings {
     enum ProjectSortOrder: String {
         case title
         case progress
+        case deadline
         case custom
+
+        var description: String {
+            switch self {
+            case .title: return NSLocalizedString("sort_title", comment: "")
+            case .progress: return NSLocalizedString("sort_progress", comment: "")
+            case .deadline: return NSLocalizedString("sort_deadline", comment: "")
+            case .custom: return NSLocalizedString("sort_custom", comment: "")
+            }
+        }
 
         var iconName: String {
             switch self {
             case .title: return "textformat"
             case .progress: return "chart.bar"
+            case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
             }
         }
@@ -290,7 +314,8 @@ final class AppSettings {
         var next: ProjectSortOrder {
             switch self {
             case .title: return .progress
-            case .progress: return .custom
+            case .progress: return .deadline
+            case .deadline: return .custom
             case .custom: return .title
             }
         }

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -54,6 +54,12 @@ struct ContentView: View {
       return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
       return projects.sorted { $0.progress > $1.progress }
+    case .deadline:
+      return projects.sorted {
+        let d0 = $0.deadline == nil ? Int.max : $0.daysLeft
+        let d1 = $1.deadline == nil ? Int.max : $1.daysLeft
+        return d0 < d1
+      }
     case .custom:
       return projects
     }

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,11 @@
 "export_project_tooltip" = "Export project";
 "import_project_tooltip" = "Import project";
 "toggle_sort_tooltip" = "Change sort order";
+"sort_title" = "By title";
+"sort_progress" = "By progress";
+"sort_deadline" = "By deadline";
+"sort_custom" = "Manual order";
+"sort_order" = "Sort order";
 "share_progress_tooltip" = "Share progress";
 "sync_document_tooltip" = "Sync document";
 "sync_type_prompt" = "Select sync source";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -76,6 +76,11 @@
 "export_project_tooltip" = "Экспортировать проект";
 "import_project_tooltip" = "Импортировать проект";
 "toggle_sort_tooltip" = "Изменить сортировку";
+"sort_title" = "По названию";
+"sort_progress" = "По прогрессу";
+"sort_deadline" = "По дедлайну";
+"sort_custom" = "Вручную";
+"sort_order" = "Сортировка";
 "share_progress_tooltip" = "Поделиться прогрессом";
 "sync_document_tooltip" = "Синхронизация";
 "sync_type_prompt" = "Выберите источник";

--- a/nfprogress/SettingsView.swift
+++ b/nfprogress/SettingsView.swift
@@ -31,6 +31,19 @@ struct SettingsView: View {
                 .fixedSize()
             }
 
+            HStack {
+                Text("sort_order")
+                    .frame(width: labelWidth, alignment: .leading)
+                Picker("", selection: $settings.projectSortOrder) {
+                    ForEach(AppSettings.ProjectSortOrder.allCases) { order in
+                        Text(order.description).tag(order)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
+            }
+
             Toggle(isOn: $settings.disableLaunchAnimations) {
                 Text("disable_launch_animations")
                     .frame(width: labelWidth, alignment: .leading)


### PR DESCRIPTION
## Summary
- provide localized names for sort orders
- expose sort order picker in Settings
- include deadline sorting description and translations

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_685df67871f08333b5ac083ffcd271db