### PR TITLE
Show project title in toolbar

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -90,7 +90,14 @@ struct ContentView: View {
 #endif
           .listStyle(.plain)
           .navigationTitle("my_texts")
-          .toolbar { toolbarContent }
+          .toolbar {
+            toolbarContent
+          }
+          .toolbar {
+            ToolbarItem(placement: .principal) {
+              OptionalProjectTitleBar(project: selectedProject)
+            }
+          }
         }, detail: {
           if let project = selectedProject {
             ProjectDetailView(project: project)
@@ -132,7 +139,14 @@ struct ContentView: View {
           .listStyle(.plain)
           .navigationTitle("my_texts")
           .navigationBarTitleDisplayMode(.inline)
-          .toolbar { toolbarContent }
+          .toolbar {
+            toolbarContent
+          }
+          .toolbar {
+            ToolbarItem(placement: .principal) {
+              OptionalProjectTitleBar(project: selectedProject)
+            }
+          }
           .navigationDestination(item: $openedProject) { project in
             ProjectDetailView(project: project)
           }
@@ -173,6 +187,11 @@ struct ContentView: View {
       .navigationTitle("my_texts")
       .toolbar { fixedToolbarContent }
       .toolbar(id: "mainToolbar") { customizableToolbarContent }
+      .toolbar {
+        ToolbarItem(placement: .principal) {
+          OptionalProjectTitleBar(project: selectedProject)
+        }
+      }
     }, detail: {
       if let project = selectedProject {
         ProjectDetailView(project: project)

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -27,7 +27,6 @@ struct ProjectDetailView: View {
     @State private var tempDeadline: Date = Date()
     @State private var selectedEntry: Entry?
     // Состояние редактирования отдельных полей
-    @State private var isEditingTitle = false
     @State private var isEditingGoal = false
     @State private var isEditingDeadline = false
     @FocusState private var focusedField: Field?
@@ -49,7 +48,7 @@ struct ProjectDetailView: View {
     }
 
     private enum Field: Hashable {
-        case title, goal, deadline
+        case goal, deadline
     }
 
     private func deadlineColor(daysLeft: Int) -> Color {
@@ -458,25 +457,6 @@ struct ProjectDetailView: View {
     private var infoSection: some View {
         // Название, цель и дедлайн проекта
         Grid(alignment: .leading, horizontalSpacing: viewSpacing / 2, verticalSpacing: viewSpacing / 2) {
-            GridRow {
-                Text("label_title_colon")
-                    .font(.title3.bold())
-                    .fixedSize(horizontal: false, vertical: true)
-                if isEditingTitle {
-                    TextField("", text: $project.title)
-                        .textFieldStyle(.roundedBorder)
-                        .submitLabel(.done)
-                        .focused($focusedField, equals: .title)
-                        .onSubmit { focusedField = nil }
-                } else {
-                    Text(project.title)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .onTapGesture {
-                            isEditingTitle = true
-                            focusedField = .title
-                        }
-                }
-            }
 
             GridRow {
                 Text("label_goal_colon")
@@ -612,10 +592,6 @@ struct ProjectDetailView: View {
             }
         }
         .onChange(of: focusedField) { newValue in
-            if newValue != .title && isEditingTitle {
-                isEditingTitle = false
-                saveContext()
-            }
             if newValue != .goal && isEditingGoal {
                 isEditingGoal = false
                 saveContext()
@@ -626,8 +602,10 @@ struct ProjectDetailView: View {
                 saveContext()
             }
         }
-        // Заголовок проекта убран из панели инструментов для простоты интерфейса
         .toolbar {
+            ToolbarItem(placement: .principal) {
+                ProjectTitleBar(project: project)
+            }
             ToolbarItem(placement: .primaryAction) {
                 shareToolbarButton()
             }

--- a/nfprogress/ProjectTitleBar.swift
+++ b/nfprogress/ProjectTitleBar.swift
@@ -1,0 +1,56 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(SwiftData)
+import SwiftData
+#endif
+
+/// Отображает название проекта в панели инструментов
+/// и позволяет редактировать его при нажатии.
+struct ProjectTitleBar: View {
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var project: WritingProject
+    @State private var isEditing = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Group {
+            if isEditing {
+                TextField("", text: $project.title)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($isFocused)
+                    .onSubmit(save)
+                    .onAppear { isFocused = true }
+                    .frame(maxWidth: 200)
+            } else {
+                Text(project.title)
+                    .font(.headline)
+                    .onTapGesture {
+                        isEditing = true
+                        isFocused = true
+                    }
+            }
+        }
+    }
+
+    private func save() {
+        isEditing = false
+        do { try modelContext.save() } catch {
+            print("Ошибка сохранения: \(error)")
+        }
+    }
+}
+
+/// Обёртка для необязательного проекта.
+struct OptionalProjectTitleBar: View {
+    var project: WritingProject?
+
+    var body: some View {
+        if let project {
+            ProjectTitleBar(project: project)
+        } else {
+            Text("nfprogress")
+                .font(.headline)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- show editable project title in the main toolbar
- remove duplicated title field from project details

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_685e0cf470f08333b7ac87bcd46f2f02