### PR TITLE
Fix default title display

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -90,13 +90,24 @@ struct ContentView: View {
 #endif
           .listStyle(.plain)
           .navigationTitle("my_texts")
-          .toolbar { toolbarContent }
+          .toolbar {
+            toolbarContent
+          }
         }, detail: {
           if let project = selectedProject {
             ProjectDetailView(project: project)
           } else {
             Text("select_project")
               .foregroundColor(.gray)
+              .toolbar {
+                ToolbarItem(placement: .principal) {
+                  OptionalProjectTitleBar(project: selectedProject)
+                }
+              }
+              .navigationTitle("")
+#if os(iOS)
+              .navigationBarTitleDisplayMode(.inline)
+#endif
           }
         })
         .navigationDestination(for: WritingProject.self) { project in
@@ -132,7 +143,9 @@ struct ContentView: View {
           .listStyle(.plain)
           .navigationTitle("my_texts")
           .navigationBarTitleDisplayMode(.inline)
-          .toolbar { toolbarContent }
+          .toolbar {
+            toolbarContent
+          }
           .navigationDestination(item: $openedProject) { project in
             ProjectDetailView(project: project)
           }
@@ -179,6 +192,15 @@ struct ContentView: View {
       } else {
         Text("select_project")
           .foregroundColor(.gray)
+          .toolbar {
+            ToolbarItem(placement: .principal) {
+              OptionalProjectTitleBar(project: selectedProject)
+            }
+          }
+          .navigationTitle("")
+#if os(iOS)
+          .navigationBarTitleDisplayMode(.inline)
+#endif
       }
     })
 #if os(macOS)

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -27,7 +27,6 @@ struct ProjectDetailView: View {
     @State private var tempDeadline: Date = Date()
     @State private var selectedEntry: Entry?
     // Состояние редактирования отдельных полей
-    @State private var isEditingTitle = false
     @State private var isEditingGoal = false
     @State private var isEditingDeadline = false
     @FocusState private var focusedField: Field?
@@ -49,7 +48,7 @@ struct ProjectDetailView: View {
     }
 
     private enum Field: Hashable {
-        case title, goal, deadline
+        case goal, deadline
     }
 
     private func deadlineColor(daysLeft: Int) -> Color {
@@ -458,25 +457,6 @@ struct ProjectDetailView: View {
     private var infoSection: some View {
         // Название, цель и дедлайн проекта
         Grid(alignment: .leading, horizontalSpacing: viewSpacing / 2, verticalSpacing: viewSpacing / 2) {
-            GridRow {
-                Text("label_title_colon")
-                    .font(.title3.bold())
-                    .fixedSize(horizontal: false, vertical: true)
-                if isEditingTitle {
-                    TextField("", text: $project.title)
-                        .textFieldStyle(.roundedBorder)
-                        .submitLabel(.done)
-                        .focused($focusedField, equals: .title)
-                        .onSubmit { focusedField = nil }
-                } else {
-                    Text(project.title)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .onTapGesture {
-                            isEditingTitle = true
-                            focusedField = .title
-                        }
-                }
-            }
 
             GridRow {
                 Text("label_goal_colon")
@@ -612,10 +592,6 @@ struct ProjectDetailView: View {
             }
         }
         .onChange(of: focusedField) { newValue in
-            if newValue != .title && isEditingTitle {
-                isEditingTitle = false
-                saveContext()
-            }
             if newValue != .goal && isEditingGoal {
                 isEditingGoal = false
                 saveContext()
@@ -626,8 +602,10 @@ struct ProjectDetailView: View {
                 saveContext()
             }
         }
-        // Заголовок проекта убран из панели инструментов для простоты интерфейса
         .toolbar {
+            ToolbarItem(placement: .principal) {
+                ProjectTitleBar(project: project)
+            }
             ToolbarItem(placement: .primaryAction) {
                 shareToolbarButton()
             }
@@ -637,6 +615,10 @@ struct ProjectDetailView: View {
             }
 #endif
         }
+        .navigationTitle("")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
         .modifier(SyncSheetsModifier(
             project: project,
             showingAddEntry: $showingAddEntry,

--- a/nfprogress/ProjectTitleBar.swift
+++ b/nfprogress/ProjectTitleBar.swift
@@ -1,0 +1,56 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(SwiftData)
+import SwiftData
+#endif
+
+/// Отображает название проекта в панели инструментов
+/// и позволяет редактировать его при нажатии.
+struct ProjectTitleBar: View {
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var project: WritingProject
+    @State private var isEditing = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Group {
+            if isEditing {
+                TextField("", text: $project.title)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($isFocused)
+                    .onSubmit(save)
+                    .onAppear { isFocused = true }
+                    .frame(maxWidth: 200)
+            } else {
+                Text(project.title)
+                    .font(.headline)
+                    .onTapGesture {
+                        isEditing = true
+                        isFocused = true
+                    }
+            }
+        }
+    }
+
+    private func save() {
+        isEditing = false
+        do { try modelContext.save() } catch {
+            print("Ошибка сохранения: \(error)")
+        }
+    }
+}
+
+/// Обёртка для необязательного проекта.
+struct OptionalProjectTitleBar: View {
+    var project: WritingProject?
+
+    var body: some View {
+        if let project {
+            ProjectTitleBar(project: project)
+        } else {
+            Text("nfprogress")
+                .font(.headline)
+        }
+    }
+}
+#endif

--- a/nfprogress/nfprogressApp.swift
+++ b/nfprogress/nfprogressApp.swift
@@ -44,7 +44,7 @@ struct nfprogressApp: App {
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
 #if os(macOS)
-                .windowTitle("NFProgress")
+                .windowTitle("")
                 .persistentWindowFrame()
                 .persistentWindowSize()
                 .windowDefaultSize(width: 810, height: 530)
@@ -65,7 +65,7 @@ struct nfprogressApp: App {
             MenuBarEntryView()
                 .environmentObject(settings)
                 .environment(\.locale, settings.locale)
-                .windowTitle("NFProgress")
+                .windowTitle("")
         }
         .menuBarExtraStyle(.window)
         .modelContainer(DataController.shared)


### PR DESCRIPTION
## Summary
- show "nfprogress" when no project is selected
- hide app name from main macOS windows

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_685e0cf470f08333b7ac87bcd46f2f02