### PR TITLE
Add macOS multi-project export

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -280,7 +280,7 @@ struct ContentView: View {
         guard selectedProject != nil else { return }
         exportSelectedProject()
       }) {
-        Image(systemName: "square.and.arrow.up")
+        Image(systemName: "tray.full")
       }
       .accessibilityLabel(settings.localized("export"))
       .help(settings.localized("export_project_tooltip"))
@@ -331,7 +331,7 @@ struct ContentView: View {
 
           if selectedProject != nil {
             Button(action: exportSelectedProject) {
-              Image(systemName: "square.and.arrow.up")
+              Image(systemName: "tray.full")
             }
             .accessibilityLabel(settings.localized("export"))
             .help(settings.localized("export_project_tooltip"))
@@ -359,7 +359,7 @@ struct ContentView: View {
             }
 
             Button(action: exportSelectedProject) {
-              Label(settings.localized("export"), systemImage: "square.and.arrow.up")
+              Label(settings.localized("export"), systemImage: "tray.full")
             }
           }
 
@@ -417,7 +417,7 @@ struct ContentView: View {
 
       if selectedProject != nil {
         Button(action: exportSelectedProject) {
-          Image(systemName: "square.and.arrow.up")
+          Image(systemName: "tray.full")
         }
         .accessibilityLabel(settings.localized("export"))
         .help(settings.localized("export_project_tooltip"))
@@ -577,7 +577,7 @@ struct ContentView: View {
   // MARK: - Экспорт
   private func exportSelectedProject() {
 #if os(macOS)
-    showSavePanel()
+    openWindow(id: "exportProjects")
 #else
     isExporting = true
 #endif

--- a/nfprogress/ExportProjectsView.swift
+++ b/nfprogress/ExportProjectsView.swift
@@ -1,0 +1,77 @@
+#if os(macOS)
+import SwiftUI
+#if canImport(SwiftData)
+import SwiftData
+#endif
+
+struct ExportProjectsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var context
+    @EnvironmentObject private var settings: AppSettings
+    @Query(sort: [SortDescriptor(\WritingProject.order)]) private var projects: [WritingProject]
+
+    @State private var selection = Set<PersistentIdentifier>()
+
+    private var selectedProjects: [WritingProject] {
+        projects.filter { selection.contains($0.id) }
+    }
+
+    var body: some View {
+        VStack {
+            List(selection: $selection) {
+                ForEach(projects) { project in
+                    Text(project.title)
+                        .tag(project.id)
+                }
+            }
+            .frame(minHeight: layoutStep(20))
+
+            HStack {
+                Spacer()
+                Button(settings.localized("export")) { export() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(selection.isEmpty)
+            }
+        }
+        .scaledPadding()
+        .frame(minWidth: layoutStep(40), minHeight: layoutStep(30))
+        .windowTitle(settings.localized("export_ellipsis"))
+        .onExitCommand { dismiss() }
+    }
+
+    private func export() {
+        let items = selectedProjects
+        guard !items.isEmpty else { return }
+        if items.count == 1, let project = items.first {
+            exportSingle(project: project)
+        } else {
+            exportMultiple(projects: items)
+        }
+        dismiss()
+    }
+
+    private func exportSingle(project: WritingProject) {
+        let csv = CSVManager.csvString(for: project)
+        let name = project.title.replacingOccurrences(of: " ", with: "_") + ".csv"
+        saveCSV(csv, defaultName: name)
+    }
+
+    private func exportMultiple(projects: [WritingProject]) {
+        let csv = CSVManager.csvString(for: projects)
+        saveCSV(csv, defaultName: "Projects.csv")
+    }
+
+    private func saveCSV(_ csv: String, defaultName: String) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.nameFieldStringValue = defaultName
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try csv.write(to: url, atomically: true, encoding: .utf8)
+            } catch {
+                print("Export failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+#endif

--- a/nfprogress/WindowScenes.swift
+++ b/nfprogress/WindowScenes.swift
@@ -194,6 +194,13 @@ extension nfprogressApp {
             }
         }
         .modelContainer(DataController.shared).modelContext(DataController.mainContext)
+
+        WindowGroup(id: "exportProjects") {
+            ExportProjectsView()
+                .environmentObject(settings)
+                .environment(\.locale, settings.locale)
+        }
+        .modelContainer(DataController.shared).modelContext(DataController.mainContext)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- change export icon to a box symbol
- open new `ExportProjectsView` window on macOS
- allow exporting several projects into a single CSV

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685e8d7857908333ab1b94cf812ce296