### PR TITLE
Add last share progress info

### DIFF
--- a/nfprogress/CSVManager.swift
+++ b/nfprogress/CSVManager.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 struct CSVManager {
     static func csvString(for project: WritingProject) -> String {
-        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent"]
+        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress"]
         let dateFormatter = ISO8601DateFormatter()
         let deadlineString = project.deadline.map { dateFormatter.string(from: $0) } ?? ""
         var all: [(Entry, Stage?)] = project.entries.map { ($0, nil) }
@@ -17,7 +17,8 @@ struct CSVManager {
             }
         }
         if all.isEmpty && emptyStages.isEmpty {
-            lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,")
+            let share = project.lastShareProgress.map(String.init) ?? ""
+            lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,,,\(share)")
         } else {
             let sorted = all.sorted { $0.0.date < $1.0.date }
             var cumulative = 0
@@ -31,18 +32,20 @@ struct CSVManager {
                 let stageGoal = stage != nil ? String(stage!.goal) : ""
                 let stageDeadline = stage?.deadline.map { dateFormatter.string(from: $0) } ?? ""
                 let stageStart = stage != nil ? String(stage!.startProgress) : ""
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent)")
+                let share = project.lastShareProgress.map(String.init) ?? ""
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share)")
             }
             for stage in emptyStages {
                 let stageDeadline = stage.deadline.map { dateFormatter.string(from: $0) } ?? ""
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,")
+                let share = project.lastShareProgress.map(String.init) ?? ""
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share)")
             }
         }
         return lines.joined(separator: "\n")
     }
 
     static func csvString(for projects: [WritingProject]) -> String {
-        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent"]
+        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress"]
         let dateFormatter = ISO8601DateFormatter()
         for project in projects {
             let deadlineString = project.deadline.map { dateFormatter.string(from: $0) } ?? ""
@@ -56,7 +59,8 @@ struct CSVManager {
                 }
             }
             if all.isEmpty && emptyStages.isEmpty {
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,")
+                let share = project.lastShareProgress.map(String.init) ?? ""
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,,,\(share)")
             } else {
                 let sorted = all.sorted { $0.0.date < $1.0.date }
                 var cumulative = 0
@@ -70,11 +74,13 @@ struct CSVManager {
                     let stageGoal = stage != nil ? String(stage!.goal) : ""
                     let stageDeadline = stage?.deadline.map { dateFormatter.string(from: $0) } ?? ""
                     let stageStart = stage != nil ? String(stage!.startProgress) : ""
-                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent)")
+                    let share = project.lastShareProgress.map(String.init) ?? ""
+                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share)")
                 }
                 for stage in emptyStages {
                     let stageDeadline = stage.deadline.map { dateFormatter.string(from: $0) } ?? ""
-                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,")
+                    let share = project.lastShareProgress.map(String.init) ?? ""
+                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share)")
                 }
             }
         }
@@ -97,6 +103,7 @@ struct CSVManager {
             let stageStart = Int(components[6]) ?? 0
             let dateStr = components[7]
             let count = Int(components[8]) ?? 0
+            let shareProgress = components.count > 11 ? Int(components[11]) : nil
 
             let project: WritingProject
             if let existing = projectsDict[title] {
@@ -105,6 +112,9 @@ struct CSVManager {
                 let deadline = dateFormatter.date(from: deadlineStr)
                 project = WritingProject(title: title, goal: goal, deadline: deadline, order: projectsDict.count)
                 projectsDict[title] = project
+            }
+            if let shareProgress {
+                project.lastShareProgress = shareProgress
             }
 
             var stage: Stage? = nil
@@ -150,6 +160,7 @@ struct CSVManager {
         var title: String
         var goal: Int
         var deadline: Date?
+        var lastShareProgress: Int?
         var entries: [JSONEntry]
         var stages: [JSONStage]
     }
@@ -161,6 +172,7 @@ struct CSVManager {
             title: project.title,
             goal: project.goal,
             deadline: project.deadline,
+            lastShareProgress: project.lastShareProgress,
             entries: project.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) },
             stages: project.stages.map { stage in
                 JSONStage(
@@ -186,6 +198,7 @@ struct CSVManager {
                 st.entries = js.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
                 return st
             }
+            proj.lastShareProgress = jp.lastShareProgress
             return proj
         }
     }

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -271,7 +271,6 @@ struct ContentView: View {
   private var customizableToolbarContent: some CustomizableToolbarContent {
     ToolbarItem(id: "export", placement: .automatic) {
       Button(action: {
-        guard selectedProject != nil else { return }
         exportSelectedProject()
       }) {
         Image(systemName: "tray.full")
@@ -323,13 +322,13 @@ struct ContentView: View {
           .accessibilityLabel(settings.localized("import"))
           .help(settings.localized("import_project_tooltip"))
 
-          if selectedProject != nil {
-            Button(action: exportSelectedProject) {
-              Image(systemName: "tray.full")
-            }
-            .accessibilityLabel(settings.localized("export"))
-            .help(settings.localized("export_project_tooltip"))
+          Button(action: exportSelectedProject) {
+            Image(systemName: "tray.full")
+          }
+          .accessibilityLabel(settings.localized("export"))
+          .help(settings.localized("export_project_tooltip"))
 
+          if selectedProject != nil {
             Button {
               settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
             } label: {
@@ -347,14 +346,12 @@ struct ContentView: View {
     } else {
       ToolbarItem(placement: .navigationBarTrailing) {
         Menu {
-          if selectedProject != nil {
-            Button(action: importSelectedProject) {
-              Label(settings.localized("import"), systemImage: "square.and.arrow.down")
-            }
+          Button(action: importSelectedProject) {
+            Label(settings.localized("import"), systemImage: "square.and.arrow.down")
+          }
 
-            Button(action: exportSelectedProject) {
-              Label(settings.localized("export"), systemImage: "tray.full")
-            }
+          Button(action: exportSelectedProject) {
+            Label(settings.localized("export"), systemImage: "tray.full")
           }
 
           Button {
@@ -409,13 +406,13 @@ struct ContentView: View {
       .accessibilityLabel(settings.localized("import"))
       .help(settings.localized("import_project_tooltip"))
 
-      if selectedProject != nil {
-        Button(action: exportSelectedProject) {
-          Image(systemName: "tray.full")
-        }
-        .accessibilityLabel(settings.localized("export"))
-        .help(settings.localized("export_project_tooltip"))
+      Button(action: exportSelectedProject) {
+        Image(systemName: "tray.full")
+      }
+      .accessibilityLabel(settings.localized("export"))
+      .help(settings.localized("export_project_tooltip"))
 
+      if selectedProject != nil {
         Button {
           settings.projectListStyle = settings.projectListStyle == .detailed ? .compact : .detailed
         } label: {

--- a/nfprogress/ImportExportView.swift
+++ b/nfprogress/ImportExportView.swift
@@ -143,11 +143,13 @@ struct ImportExportView: View {
                 let lastScrivenerChars = current.lastScrivenerCharacters
                 let lastWordMod = current.lastWordModified
                 let lastScrivenerMod = current.lastScrivenerModified
+                let lastShare = current.lastShareProgress
 
                 current.goal = imported.goal
                 current.deadline = imported.deadline
                 current.entries = imported.entries
                 current.stages = imported.stages
+                current.lastShareProgress = imported.lastShareProgress
 
                 for stage in current.stages {
                     if let old = stageSyncInfo[stage.title] {
@@ -176,6 +178,9 @@ struct ImportExportView: View {
                 current.lastScrivenerCharacters = lastScrivenerChars
                 current.lastWordModified = lastWordMod
                 current.lastScrivenerModified = lastScrivenerMod
+                if current.lastShareProgress == nil {
+                    current.lastShareProgress = lastShare
+                }
             } else {
                 context.insert(imported)
             }

--- a/nfprogress/ProgressShareImage.swift
+++ b/nfprogress/ProgressShareImage.swift
@@ -29,7 +29,7 @@ private struct ProgressCircleSnapshotView: View {
     var percentFontSize: CGFloat
 
     private var previousProgress: Int {
-        settings.lastShareProgress[String(describing: project.id)] ?? project.currentProgress
+        project.lastShareProgress ?? settings.lastShareProgress[String(describing: project.id)] ?? project.currentProgress
     }
 
     private var previousFraction: Double {

--- a/nfprogress/ProgressSharePreview.swift
+++ b/nfprogress/ProgressSharePreview.swift
@@ -221,6 +221,7 @@ struct ProgressSharePreview: View {
         settings.lastShareTitleOffset = Double(titleOffset)
         let key = String(describing: project.id)
         settings.lastShareProgress[key] = project.currentProgress
+        project.lastShareProgress = project.currentProgress
     }
 
     @ViewBuilder

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -33,6 +33,8 @@ class WritingProject {
     /// Дата последнего изменения файла Word
     var lastWordModified: Date?
     var lastScrivenerModified: Date?
+    /// Прогресс в момент последнего шеринга
+    var lastShareProgress: Int?
 
     init(title: String, goal: Int, deadline: Date? = nil, order: Int = 0, isChartCollapsed: Bool = false) {
         self.title = title


### PR DESCRIPTION
## Summary
- track progress at last share within `WritingProject`
- include last share progress in CSV and JSON import/export
- use project property when generating share image
- persist last share progress when sharing
- import/export view preserves value on replace
- enable Import/Export button even without a selected project

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_686226e036a88333aed5adea6ffea2d8