### PR TITLE
Добавлена кнопка "Показать в Finder" в окно синхронизации

### DIFF
--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -96,8 +96,9 @@
 "share_mode_now" = "Now";
 "charts_framework_required" = "Charts framework is required";
 "scrivener_parse_error" = "Failed to load Scrivener project";
-"sync_info_word" = "Word file:\n%@";
-"sync_info_scrivener" = "Scrivener item %@\nin project:\n%@";
+"sync_info_word" = "Word file:";
+"sync_info_scrivener" = "Scrivener item %@";
+"show_in_finder" = "Show in Finder";
 "close" = "Close";
 "unlink" = "Unlink";
 "pause_sync" = "Pause sync";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -97,8 +97,9 @@
 "share_mode_now" = "Сейчас";
 "charts_framework_required" = "Для отображения графика требуется фреймворк Charts";
 "scrivener_parse_error" = "Не удалось загрузить проект Scrivener";
-"sync_info_word" = "Файл Word:\n%@";
-"sync_info_scrivener" = "Элемент Scrivener %@\nв проекте:\n%@";
+"sync_info_word" = "Файл Word:";
+"sync_info_scrivener" = "Элемент Scrivener %@";
+"show_in_finder" = "Показать в Finder";
 "close" = "Закрыть";
 "unlink" = "Отвязать";
 "pause_sync" = "Приостановить синхронизацию";


### PR DESCRIPTION
## Изменения
- кнопка "Показать в Finder" вместо отображения пути к синхронизации
- поддержка новой локализации для кнопки и обновлённые строки описания
- открытие Finder с выделением файла по нажатию на кнопку
- актуализация тестов — все проходят

## Тестирование
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6862384dd2fc8333a6f48bd92de53d97