### PR TITLE
Реализация обновлённого импорта и сохранения названия

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
   @State private var showDeleteAlert = false
   @State private var importConflictProjects: [WritingProject] = []
   @State private var showImportConflictAlert = false
+  @State private var showImportFailedAlert = false
 #if os(iOS)
   @State private var editMode: EditMode = .inactive
 #endif
@@ -486,6 +487,9 @@ struct ContentView: View {
         Button(settings.localized("keep_all")) { keepAllImport() }
         Button(settings.localized("replace")) { replaceImport() }
       }
+      .alert(settings.localized("import_failed"), isPresented: $showImportFailedAlert) {
+        Button("OK", role: .cancel) { }
+      }
       .onReceive(NotificationCenter.default.publisher(for: .menuAddProject)) { _ in
         addProject()
       }
@@ -608,8 +612,17 @@ struct ContentView: View {
   private func importCSV(from url: URL) {
     guard let data = try? Data(contentsOf: url),
       let text = String(data: data, encoding: .utf8)
-    else { return }
+    else {
+      showImportFailedAlert = true
+      isImporting = false
+      return
+    }
     let imported = CSVManager.importProjects(from: text)
+    guard !imported.isEmpty else {
+      showImportFailedAlert = true
+      isImporting = false
+      return
+    }
     let existingTitles = Set(projects.map { $0.title })
     if imported.contains(where: { existingTitles.contains($0.title) }) {
       importConflictProjects = imported
@@ -620,6 +633,7 @@ struct ContentView: View {
       }
       try? modelContext.save()
       isImporting = false
+      sendNotification(key: "import_success")
     }
   }
 
@@ -635,6 +649,7 @@ struct ContentView: View {
     importConflictProjects = []
     showImportConflictAlert = false
     isImporting = false
+    sendNotification(key: "projects_imported_copies_marked")
   }
 
   private func replaceImport() {
@@ -697,16 +712,16 @@ struct ContentView: View {
     importConflictProjects = []
     showImportConflictAlert = false
     isImporting = false
-    sendNotification()
+    sendNotification(key: "projects_imported_sync_saved")
   }
 
-  private func sendNotification() {
+  private func sendNotification(key: String) {
     #if canImport(UserNotifications)
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options: [.alert]) { granted, _ in
       guard granted else { return }
       let content = UNMutableNotificationContent()
-      content.body = settings.localized("projects_imported_sync_saved")
+      content.body = settings.localized(key)
       let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
       center.add(request)
     }

--- a/nfprogress/ImportExportView.swift
+++ b/nfprogress/ImportExportView.swift
@@ -18,6 +18,7 @@ struct ImportExportView: View {
     @State private var isImporting = false
     @State private var pendingImport: [WritingProject] = []
     @State private var showConflictAlert = false
+    @State private var showImportFailedAlert = false
 
     private var selectedProjects: [WritingProject] {
         projects.filter { selection.contains($0.id) }
@@ -60,6 +61,9 @@ struct ImportExportView: View {
             Button(settings.localized("keep_all")) { keepAll() }
             Button(settings.localized("replace")) { replaceAll() }
         }
+        .alert(settings.localized("import_failed"), isPresented: $showImportFailedAlert) {
+            Button("OK", role: .cancel) { }
+        }
     }
 
     private func export() {
@@ -99,8 +103,15 @@ struct ImportExportView: View {
 
     private func importCSV(from url: URL) {
         guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else { return }
+              let text = String(data: data, encoding: .utf8) else {
+            showImportFailedAlert = true
+            return
+        }
         let imported = CSVManager.importProjects(from: text)
+        guard !imported.isEmpty else {
+            showImportFailedAlert = true
+            return
+        }
         let existingTitles = Set(projects.map { $0.title })
         if imported.contains(where: { existingTitles.contains($0.title) }) {
             pendingImport = imported
@@ -110,6 +121,8 @@ struct ImportExportView: View {
                 context.insert(project)
             }
             try? context.save()
+            dismiss()
+            sendNotification(key: "import_success")
         }
     }
 
@@ -125,6 +138,7 @@ struct ImportExportView: View {
         pendingImport = []
         showConflictAlert = false
         dismiss()
+        sendNotification(key: "projects_imported_copies_marked")
     }
 
     private func replaceAll() {
@@ -192,16 +206,16 @@ struct ImportExportView: View {
         pendingImport = []
         showConflictAlert = false
         dismiss()
-        sendNotification()
+        sendNotification(key: "projects_imported_sync_saved")
     }
 
-    private func sendNotification() {
+    private func sendNotification(key: String) {
         #if canImport(UserNotifications)
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert]) { granted, _ in
             guard granted else { return }
             let content = UNMutableNotificationContent()
-            content.body = settings.localized("projects_imported_sync_saved")
+            content.body = settings.localized(key)
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
             center.add(request)
         }

--- a/nfprogress/ProjectTitleBar.swift
+++ b/nfprogress/ProjectTitleBar.swift
@@ -20,6 +20,12 @@ struct ProjectTitleBar: View {
                     .focused($isFocused)
                     .onSubmit(save)
                     .onAppear { isFocused = true }
+                    .onChange(of: isFocused) { focused in
+                        if !focused { save() }
+                    }
+#if os(macOS)
+                    .onExitCommand { save() }
+#endif
                     .frame(maxWidth: 200)
             } else {
                 Text(project.title)
@@ -29,6 +35,9 @@ struct ProjectTitleBar: View {
                         isFocused = true
                     }
             }
+        }
+        .onDisappear {
+            if isEditing { save() }
         }
     }
 

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -119,3 +119,6 @@
 "keep_all" = "Keep All";
 "replace" = "Replace";
 "projects_imported_sync_saved" = "Projects imported, synchronization preserved";
+"projects_imported_copies_marked" = "Projects imported, copies labeled separately";
+"import_success" = "Import completed successfully";
+"import_failed" = "Import failed";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -120,3 +120,6 @@
 "keep_all" = "Оставить все";
 "replace" = "Заменить";
 "projects_imported_sync_saved" = "Проекты импортированы, синхронизация сохранена";
+"projects_imported_copies_marked" = "Проекты импортированы, копии помечены отдельно";
+"import_success" = "Импорт успешно завершен";
+"import_failed" = "Импорт не состоялся";


### PR DESCRIPTION
## Изменения
- автоматическое сохранение названия проекта при потере фокуса
- возможность закрытия окон по Esc и сохранение названия в этот момент
- уведомления при разных вариантах импорта проектов
- отображение ошибки при неудачном импорте
- новые строки локализации

## Проверка
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_68626405cc588333a4378bd538d97af2