### PR TITLE
Реализация обновлённого импорта и сохранения названия

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
   @State private var showDeleteAlert = false
   @State private var importConflictProjects: [WritingProject] = []
   @State private var showImportConflictAlert = false
+  @State private var showImportFailedAlert = false
 #if os(iOS)
   @State private var editMode: EditMode = .inactive
 #endif
@@ -486,6 +487,9 @@ struct ContentView: View {
         Button(settings.localized("keep_all")) { keepAllImport() }
         Button(settings.localized("replace")) { replaceImport() }
       }
+      .alert(settings.localized("import_failed"), isPresented: $showImportFailedAlert) {
+        Button("OK", role: .cancel) { }
+      }
       .onReceive(NotificationCenter.default.publisher(for: .menuAddProject)) { _ in
         addProject()
       }
@@ -608,8 +612,17 @@ struct ContentView: View {
   private func importCSV(from url: URL) {
     guard let data = try? Data(contentsOf: url),
       let text = String(data: data, encoding: .utf8)
-    else { return }
+    else {
+      showImportFailedAlert = true
+      isImporting = false
+      return
+    }
     let imported = CSVManager.importProjects(from: text)
+    guard !imported.isEmpty else {
+      showImportFailedAlert = true
+      isImporting = false
+      return
+    }
     let existingTitles = Set(projects.map { $0.title })
     if imported.contains(where: { existingTitles.contains($0.title) }) {
       importConflictProjects = imported
@@ -620,6 +633,7 @@ struct ContentView: View {
       }
       try? modelContext.save()
       isImporting = false
+      sendNotification(key: "import_success")
     }
   }
 
@@ -635,6 +649,7 @@ struct ContentView: View {
     importConflictProjects = []
     showImportConflictAlert = false
     isImporting = false
+    sendNotification(key: "projects_imported_copies_marked")
   }
 
   private func replaceImport() {
@@ -697,16 +712,16 @@ struct ContentView: View {
     importConflictProjects = []
     showImportConflictAlert = false
     isImporting = false
-    sendNotification()
+    sendNotification(key: "projects_imported_sync_saved")
   }
 
-  private func sendNotification() {
+  private func sendNotification(key: String) {
     #if canImport(UserNotifications)
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options: [.alert]) { granted, _ in
       guard granted else { return }
       let content = UNMutableNotificationContent()
-      content.body = settings.localized("projects_imported_sync_saved")
+      content.body = settings.localized(key)
       let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
       center.add(request)
     }

--- a/nfprogress/ImportExportView.swift
+++ b/nfprogress/ImportExportView.swift
@@ -18,6 +18,7 @@ struct ImportExportView: View {
     @State private var isImporting = false
     @State private var pendingImport: [WritingProject] = []
     @State private var showConflictAlert = false
+    @State private var showImportFailedAlert = false
 
     private var selectedProjects: [WritingProject] {
         projects.filter { selection.contains($0.id) }
@@ -60,6 +61,9 @@ struct ImportExportView: View {
             Button(settings.localized("keep_all")) { keepAll() }
             Button(settings.localized("replace")) { replaceAll() }
         }
+        .alert(settings.localized("import_failed"), isPresented: $showImportFailedAlert) {
+            Button("OK", role: .cancel) { }
+        }
     }
 
     private func export() {
@@ -99,8 +103,15 @@ struct ImportExportView: View {
 
     private func importCSV(from url: URL) {
         guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else { return }
+              let text = String(data: data, encoding: .utf8) else {
+            showImportFailedAlert = true
+            return
+        }
         let imported = CSVManager.importProjects(from: text)
+        guard !imported.isEmpty else {
+            showImportFailedAlert = true
+            return
+        }
         let existingTitles = Set(projects.map { $0.title })
         if imported.contains(where: { existingTitles.contains($0.title) }) {
             pendingImport = imported
@@ -110,6 +121,8 @@ struct ImportExportView: View {
                 context.insert(project)
             }
             try? context.save()
+            dismiss()
+            sendNotification(key: "import_success")
         }
     }
 
@@ -125,6 +138,7 @@ struct ImportExportView: View {
         pendingImport = []
         showConflictAlert = false
         dismiss()
+        sendNotification(key: "projects_imported_copies_marked")
     }
 
     private func replaceAll() {
@@ -192,16 +206,16 @@ struct ImportExportView: View {
         pendingImport = []
         showConflictAlert = false
         dismiss()
-        sendNotification()
+        sendNotification(key: "projects_imported_sync_saved")
     }
 
-    private func sendNotification() {
+    private func sendNotification(key: String) {
         #if canImport(UserNotifications)
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert]) { granted, _ in
             guard granted else { return }
             let content = UNMutableNotificationContent()
-            content.body = settings.localized("projects_imported_sync_saved")
+            content.body = settings.localized(key)
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
             center.add(request)
         }

--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -106,6 +106,8 @@ struct ProgressCircleView: View {
     @State private var duration: Double = 0.25
     /// Флаг, показывающий, что видимая часть сейчас на экране.
     @State private var isVisible = false
+    /// Последнее известное значение прогресса
+    @State private var lastProgress: Double?
 
     /// Преобразует значение прогресса в цвет от красного к зелёному
     private func color(for percent: Double) -> Color {
@@ -207,29 +209,25 @@ struct ProgressCircleView: View {
         }
         .onAppear {
             isVisible = true
-            let last = trackProgress ? ProgressAnimationTracker.lastProgress(for: project) : nil
+            let saved = trackProgress ? ProgressAnimationTracker.lastProgress(for: project) : lastProgress
 
             if disableLaunchAnimations || disableAllAnimations {
                 startProgress = progress
                 endProgress = progress
-            } else if let last {
-                startProgress = last
-                endProgress = last
-                if abs(last - progress) > 0.0001 {
-                    DispatchQueue.main.async {
-                        updateProgress(to: progress)
-                    }
+            } else if let saved {
+                startProgress = saved
+                endProgress = saved
+                if abs(saved - progress) > 0.0001 {
+                    DispatchQueue.main.async { updateProgress(to: progress) }
                 }
             } else {
                 let elapsed = Date().timeIntervalSince(AppLaunch.launchDate)
-                // Чем больше проектов, тем более растягиваем начало анимации
                 let step = 0.3 + Double(totalCount) * 0.02
                 let delay = max(0, 1 - elapsed) + Double(index) * step
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                    updateProgress(to: progress)
-                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { updateProgress(to: progress) }
             }
 
+            lastProgress = progress
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
@@ -242,6 +240,7 @@ struct ProgressCircleView: View {
             if trackProgress && isVisible {
                 ProgressAnimationTracker.setProgress(newValue, for: project)
             }
+            lastProgress = newValue
         }
         .onChange(of: project.entries.map { $0.id }) { _ in
             if trackProgress && isVisible {
@@ -250,6 +249,7 @@ struct ProgressCircleView: View {
             if isVisible {
                 updateProgress(to: progress, animated: !disableAllAnimations)
             }
+            lastProgress = progress
         }
         .onChange(of: project.stages.flatMap { $0.entries }.map { $0.id }) { _ in
             if trackProgress && isVisible {
@@ -258,6 +258,7 @@ struct ProgressCircleView: View {
             if isVisible {
                 updateProgress(to: progress, animated: !disableAllAnimations)
             }
+            lastProgress = progress
         }
         .onReceive(NotificationCenter.default.publisher(for: .projectProgressChanged)) { note in
             if let id = note.object as? PersistentIdentifier, id == project.id {
@@ -267,6 +268,7 @@ struct ProgressCircleView: View {
                 if isVisible {
                     updateProgress(to: progress, animated: !disableAllAnimations)
                 }
+                lastProgress = progress
             }
         }
     }

--- a/nfprogress/ProjectTitleBar.swift
+++ b/nfprogress/ProjectTitleBar.swift
@@ -15,11 +15,15 @@ struct ProjectTitleBar: View {
     var body: some View {
         Group {
             if isEditing {
-                TextField("", text: $project.title)
+                TextField("", text: $project.title, onEditingChanged: { editing in
+                        if !editing { save() }
+                    }, onCommit: save)
                     .textFieldStyle(.roundedBorder)
                     .focused($isFocused)
-                    .onSubmit(save)
                     .onAppear { isFocused = true }
+#if os(macOS)
+                    .onExitCommand { save() }
+#endif
                     .frame(maxWidth: 200)
             } else {
                 Text(project.title)
@@ -29,6 +33,9 @@ struct ProjectTitleBar: View {
                         isFocused = true
                     }
             }
+        }
+        .onDisappear {
+            if isEditing { save() }
         }
     }
 

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -119,3 +119,6 @@
 "keep_all" = "Keep All";
 "replace" = "Replace";
 "projects_imported_sync_saved" = "Projects imported, synchronization preserved";
+"projects_imported_copies_marked" = "Projects imported, copies labeled separately";
+"import_success" = "Import completed successfully";
+"import_failed" = "Import failed";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -120,3 +120,6 @@
 "keep_all" = "Оставить все";
 "replace" = "Заменить";
 "projects_imported_sync_saved" = "Проекты импортированы, синхронизация сохранена";
+"projects_imported_copies_marked" = "Проекты импортированы, копии помечены отдельно";
+"import_success" = "Импорт успешно завершен";
+"import_failed" = "Импорт не состоялся";


### PR DESCRIPTION
## Изменения
- автоматическое сохранение названия проекта при потере фокуса
- возможность закрытия окон по Esc и сохранение названия в этот момент
- уведомления при разных вариантах импорта проектов
- отображение ошибки при неудачном импорте
- новые строки локализации
- фиксировано сохранение названия по клику в любом месте
- анимация прогресса перезапускается только при фактическом изменении прогресса

## Проверка
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_68626405cc588333a4378bd538d97af2