### PR TITLE
Устранить повторный запуск анимации для всех проектов

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -510,7 +510,14 @@ struct ContentView: View {
 #if os(macOS)
     .onExitCommand { selectedProject = nil }
     .windowMinWidth(minWindowWidth)
-    .onAppear { settings.applyToolbarCustomization() }
+#endif
+    .onAppear {
+      settings.applyToolbarCustomization()
+#if canImport(SwiftData)
+      ProgressAnimationTracker.initialize(with: projects)
+#endif
+    }
+#if os(macOS)
     .onChange(of: selectedProject) { _ in
       settings.applyToolbarCustomization()
     }

--- a/nfprogress/ProgressAnimationTracker.swift
+++ b/nfprogress/ProgressAnimationTracker.swift
@@ -1,10 +1,13 @@
 import Foundation
+/// Запоминает последний прогресс проектов, чтобы избежать повторного запуска
+/// анимации с нуля при изменении данных проекта.
 #if canImport(SwiftData)
 import SwiftData
 
 @MainActor
 enum ProgressAnimationTracker {
     private static var progressMap: [PersistentIdentifier: Double] = [:]
+    private static var observer: NSObjectProtocol?
 
     static func lastProgress(for project: WritingProject) -> Double? {
         progressMap[project.id]
@@ -12,6 +15,22 @@ enum ProgressAnimationTracker {
 
     static func setProgress(_ value: Double, for project: WritingProject) {
         progressMap[project.id] = value
+    }
+
+    /// Подготавливает трекер, сбрасывая стартовый прогресс до нуля и
+    /// подписываясь на уведомления об изменении прогресса.
+    static func initialize(with projects: [WritingProject]) {
+        projects.forEach { setProgress(0, for: $0) }
+        guard observer == nil else { return }
+        observer = NotificationCenter.default.addObserver(forName: .projectProgressChanged,
+                                                         object: nil,
+                                                         queue: .main) { note in
+            guard let id = note.object as? PersistentIdentifier else { return }
+            let descriptor = FetchDescriptor<WritingProject>(predicate: #Predicate { $0.id == id })
+            if let project = try? DataController.mainContext.fetch(descriptor).first {
+                setProgress(project.progress, for: project)
+            }
+        }
     }
 }
 #endif

--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -279,6 +279,22 @@ struct ProgressCircleView: View {
             endProgress = progress
             lastProgress = progress
         }
+        .onChange(of: project.deadline) { _ in
+            if trackProgress {
+                ProgressAnimationTracker.setProgress(progress, for: project)
+            }
+            startProgress = progress
+            endProgress = progress
+            lastProgress = progress
+        }
+        .onChange(of: project.goal) { _ in
+            if trackProgress {
+                ProgressAnimationTracker.setProgress(progress, for: project)
+            }
+            startProgress = progress
+            endProgress = progress
+            lastProgress = progress
+        }
     }
 }
 

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -244,6 +244,9 @@ struct ProjectDetailView: View {
         private func saveContext() {
             do {
                 try modelContext.save()
+                #if canImport(SwiftData)
+                ProgressAnimationTracker.setProgress(project.progress, for: project)
+                #endif
             } catch {
                 print("Ошибка сохранения: \(error)")
             }
@@ -603,6 +606,21 @@ struct ProjectDetailView: View {
                 saveContext()
             }
         }
+        .onChange(of: project.title) { _ in
+#if canImport(SwiftData)
+            ProgressAnimationTracker.setProgress(project.progress, for: project)
+#endif
+        }
+        .onChange(of: project.deadline) { _ in
+#if canImport(SwiftData)
+            ProgressAnimationTracker.setProgress(project.progress, for: project)
+#endif
+        }
+        .onChange(of: project.goal) { _ in
+#if canImport(SwiftData)
+            ProgressAnimationTracker.setProgress(project.progress, for: project)
+#endif
+        }
         .toolbar {
             ToolbarItem(placement: .principal) {
                 ProjectTitleBar(project: project)
@@ -641,6 +659,9 @@ struct ProjectDetailView: View {
     private func saveContext() {
         do {
             try modelContext.save()
+            #if canImport(SwiftData)
+            ProgressAnimationTracker.setProgress(project.progress, for: project)
+            #endif
         } catch {
             print("Ошибка сохранения: \(error)")
         }

--- a/nfprogress/ProjectListViews.swift
+++ b/nfprogress/ProjectListViews.swift
@@ -131,6 +131,18 @@ struct ProjectPercentView: View {
                 updateProgress(to: progress, animated: false)
             }
         }
+        .onChange(of: project.deadline) { _ in
+            if isVisible {
+                ProgressAnimationTracker.setProgress(progress, for: project)
+                updateProgress(to: progress, animated: false)
+            }
+        }
+        .onChange(of: project.goal) { _ in
+            if isVisible {
+                ProgressAnimationTracker.setProgress(progress, for: project)
+                updateProgress(to: progress, animated: false)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- track progress updates via notification
- preload progress for all projects on app launch
- initialize tracker when main view appears
- fix progress animation initialization

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68628d063bdc8333b4f337fa799a9130