### PR TITLE
Fix progress animation restart across projects

### DIFF
--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -108,6 +108,12 @@ struct ProgressCircleView: View {
     @State private var isVisible = false
     /// Последнее известное значение прогресса
     @State private var lastProgress: Double?
+    /// Предыдущее название проекта
+    @State private var lastTitle: String = ""
+    /// Предыдущий дедлайн проекта
+    @State private var lastDeadline: Date?
+    /// Предыдущая цель проекта
+    @State private var lastGoal: Int = 0
 
     /// Преобразует значение прогресса в цвет от красного к зелёному
     private func color(for percent: Double) -> Color {
@@ -231,6 +237,9 @@ struct ProgressCircleView: View {
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
+            lastTitle = project.title
+            lastDeadline = project.deadline
+            lastGoal = project.goal
         }
         .onDisappear { isVisible = false }
         .onChange(of: progress) { newValue in
@@ -271,23 +280,23 @@ struct ProgressCircleView: View {
                 lastProgress = progress
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            guard newValue != lastTitle else { return }
+            lastTitle = newValue
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            guard newValue != lastDeadline else { return }
+            lastDeadline = newValue
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            guard newValue != lastGoal else { return }
+            lastGoal = newValue
             if trackProgress {
                 ProgressAnimationTracker.setProgress(0, for: project)
             }

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -34,6 +34,12 @@ struct ProjectDetailView: View {
 #if os(iOS)
     @State private var showingSharePreview = false
 #endif
+    /// Предыдущее значение названия проекта
+    @State private var lastTitle: String = ""
+    /// Предыдущее значение дедлайна проекта
+    @State private var lastDeadline: Date?
+    /// Предыдущее значение цели проекта
+    @State private var lastGoal: Int = 0
 
     /// Базовый отступ между секциями истории и этапов.
     private let viewSpacing: CGFloat = scaledSpacing(2)
@@ -568,6 +574,9 @@ struct ProjectDetailView: View {
                 DocumentSyncManager.startMonitoring(project: project)
             }
 #endif
+            lastTitle = project.title
+            lastDeadline = project.deadline
+            lastGoal = project.goal
         }
         .onReceive(NotificationCenter.default.publisher(for: .menuAddEntry)) { _ in
             addEntry()
@@ -607,17 +616,23 @@ struct ProjectDetailView: View {
                 saveContext()
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            guard newValue != lastTitle else { return }
+            lastTitle = newValue
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(project.progress, for: project)
 #endif
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            guard newValue != lastDeadline else { return }
+            lastDeadline = newValue
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(project.progress, for: project)
 #endif
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            guard newValue != lastGoal else { return }
+            lastGoal = newValue
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(0, for: project)
             goalChanged = true

--- a/nfprogress/ProjectListViews.swift
+++ b/nfprogress/ProjectListViews.swift
@@ -25,6 +25,12 @@ struct ProjectPercentView: View {
     @State private var duration: Double = 0.25
     /// Показывает, что представление в данный момент видно.
     @State private var isVisible = false
+    /// Предыдущее значение названия проекта
+    @State private var lastTitle: String = ""
+    /// Предыдущее значение дедлайна проекта
+    @State private var lastDeadline: Date?
+    /// Предыдущее значение цели проекта
+    @State private var lastGoal: Int = 0
 
     private let minDuration = 0.25
     private let maxDuration = 3.0
@@ -97,6 +103,9 @@ struct ProjectPercentView: View {
                 }
             }
             ProgressAnimationTracker.setProgress(progress, for: project)
+            lastTitle = project.title
+            lastDeadline = project.deadline
+            lastGoal = project.goal
         }
         .onDisappear { isVisible = false }
         .onChange(of: progress) { newValue in
@@ -125,19 +134,23 @@ struct ProjectPercentView: View {
                 }
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            guard newValue != lastTitle else { return }
+            lastTitle = newValue
             if isVisible {
                 ProgressAnimationTracker.setProgress(progress, for: project)
-                updateProgress(to: progress, animated: false)
             }
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            guard newValue != lastDeadline else { return }
+            lastDeadline = newValue
             if isVisible {
                 ProgressAnimationTracker.setProgress(progress, for: project)
-                updateProgress(to: progress, animated: false)
             }
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            guard newValue != lastGoal else { return }
+            lastGoal = newValue
             if isVisible {
                 ProgressAnimationTracker.setProgress(0, for: project)
                 startProgress = 0


### PR DESCRIPTION
## Summary
- avoid resetting progress animation when only the name or deadline changes
- keep previous goal change logic for starting animation from zero

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_68629a88e8c88333b8043e2faea01faa