### PR TITLE
Fix progress animation restart across projects

### DIFF
--- a/nfprogress/ProgressAnimationTracker.swift
+++ b/nfprogress/ProgressAnimationTracker.swift
@@ -7,6 +7,9 @@ import SwiftData
 @MainActor
 enum ProgressAnimationTracker {
     private static var progressMap: [PersistentIdentifier: Double] = [:]
+    private static var titleMap: [PersistentIdentifier: String] = [:]
+    private static var deadlineMap: [PersistentIdentifier: Date?] = [:]
+    private static var goalMap: [PersistentIdentifier: Int] = [:]
     private static var observer: NSObjectProtocol?
 
     static func lastProgress(for project: WritingProject) -> Double? {
@@ -17,11 +20,46 @@ enum ProgressAnimationTracker {
         progressMap[project.id] = value
     }
 
+    static func lastTitle(for project: WritingProject) -> String? {
+        titleMap[project.id]
+    }
+
+    static func setTitle(_ value: String, for project: WritingProject) {
+        titleMap[project.id] = value
+    }
+
+    static func lastDeadline(for project: WritingProject) -> Date?? {
+        deadlineMap[project.id]
+    }
+
+    static func setDeadline(_ value: Date?, for project: WritingProject) {
+        deadlineMap[project.id] = value
+    }
+
+    static func lastGoal(for project: WritingProject) -> Int? {
+        goalMap[project.id]
+    }
+
+    static func setGoal(_ value: Int, for project: WritingProject) {
+        goalMap[project.id] = value
+    }
+
+    static func updateAttributes(for project: WritingProject) {
+        setTitle(project.title, for: project)
+        setDeadline(project.deadline, for: project)
+        setGoal(project.goal, for: project)
+    }
+
     /// Подготавливает трекер, сбрасывая стартовый прогресс до нуля и
     /// подписываясь на уведомления об изменении прогресса.
     static func initialize(with projects: [WritingProject]) {
         if progressMap.isEmpty {
-            projects.forEach { setProgress(0, for: $0) }
+            projects.forEach {
+                setProgress(0, for: $0)
+                setTitle($0.title, for: $0)
+                setDeadline($0.deadline, for: $0)
+                setGoal($0.goal, for: $0)
+            }
         }
         guard observer == nil else { return }
         observer = NotificationCenter.default.addObserver(forName: .projectProgressChanged,

--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -231,6 +231,7 @@ struct ProgressCircleView: View {
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
+            ProgressAnimationTracker.updateAttributes(for: project)
         }
         .onDisappear { isVisible = false }
         .onChange(of: progress) { newValue in
@@ -271,23 +272,23 @@ struct ProgressCircleView: View {
                 lastProgress = progress
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            if let old = ProgressAnimationTracker.lastTitle(for: project), old == newValue { return }
+            ProgressAnimationTracker.setTitle(newValue, for: project)
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            if let old = ProgressAnimationTracker.lastDeadline(for: project), old == newValue { return }
+            ProgressAnimationTracker.setDeadline(newValue, for: project)
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            if let old = ProgressAnimationTracker.lastGoal(for: project), old == newValue { return }
+            ProgressAnimationTracker.setGoal(newValue, for: project)
             if trackProgress {
                 ProgressAnimationTracker.setProgress(0, for: project)
             }

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -568,6 +568,7 @@ struct ProjectDetailView: View {
                 DocumentSyncManager.startMonitoring(project: project)
             }
 #endif
+            ProgressAnimationTracker.updateAttributes(for: project)
         }
         .onReceive(NotificationCenter.default.publisher(for: .menuAddEntry)) { _ in
             addEntry()
@@ -607,17 +608,23 @@ struct ProjectDetailView: View {
                 saveContext()
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            if let old = ProgressAnimationTracker.lastTitle(for: project), old == newValue { return }
+            ProgressAnimationTracker.setTitle(newValue, for: project)
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(project.progress, for: project)
 #endif
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            if let old = ProgressAnimationTracker.lastDeadline(for: project), old == newValue { return }
+            ProgressAnimationTracker.setDeadline(newValue, for: project)
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(project.progress, for: project)
 #endif
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            if let old = ProgressAnimationTracker.lastGoal(for: project), old == newValue { return }
+            ProgressAnimationTracker.setGoal(newValue, for: project)
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(0, for: project)
             goalChanged = true

--- a/nfprogress/ProjectListViews.swift
+++ b/nfprogress/ProjectListViews.swift
@@ -97,6 +97,7 @@ struct ProjectPercentView: View {
                 }
             }
             ProgressAnimationTracker.setProgress(progress, for: project)
+            ProgressAnimationTracker.updateAttributes(for: project)
         }
         .onDisappear { isVisible = false }
         .onChange(of: progress) { newValue in
@@ -125,19 +126,23 @@ struct ProjectPercentView: View {
                 }
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            if let old = ProgressAnimationTracker.lastTitle(for: project), old == newValue { return }
+            ProgressAnimationTracker.setTitle(newValue, for: project)
             if isVisible {
                 ProgressAnimationTracker.setProgress(progress, for: project)
-                updateProgress(to: progress, animated: false)
             }
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            if let old = ProgressAnimationTracker.lastDeadline(for: project), old == newValue { return }
+            ProgressAnimationTracker.setDeadline(newValue, for: project)
             if isVisible {
                 ProgressAnimationTracker.setProgress(progress, for: project)
-                updateProgress(to: progress, animated: false)
             }
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            if let old = ProgressAnimationTracker.lastGoal(for: project), old == newValue { return }
+            ProgressAnimationTracker.setGoal(newValue, for: project)
             if isVisible {
                 ProgressAnimationTracker.setProgress(0, for: project)
                 startProgress = 0


### PR DESCRIPTION
## Summary
- prevent progress resets when project title or deadline changes by storing previous values in `ProgressAnimationTracker`
- update detail and list views to check stored attributes
- remove local state trackers for titles, deadlines and goals

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_68629a88e8c88333b8043e2faea01faa