### PR TITLE
Fix progress animation on title/deadline changes

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -231,11 +231,11 @@ struct ContentView: View {
         HStack {
           Spacer()
 #if os(iOS)
-          ProgressCircleView(project: project, index: index, totalCount: totalCount, style: .large)
+          ProgressCircleView(project: project, index: index, totalCount: totalCount, isSelected: selectedProject === project, style: .large)
             .id(project.id)
             .frame(height: largeCircleHeight)
 #else
-          ProgressCircleView(project: project, index: index, totalCount: totalCount)
+          ProgressCircleView(project: project, index: index, totalCount: totalCount, isSelected: selectedProject === project)
             .id(project.id)
             .frame(height: circleHeight)
 #endif
@@ -243,7 +243,7 @@ struct ContentView: View {
         }
       }
     case .compact:
-      CompactProjectRow(project: project, index: index, totalCount: totalCount)
+      CompactProjectRow(project: project, index: index, totalCount: totalCount, isSelected: selectedProject === project)
         .id(project.id)
     }
   }

--- a/nfprogress/ProgressAnimationTracker.swift
+++ b/nfprogress/ProgressAnimationTracker.swift
@@ -7,6 +7,9 @@ import SwiftData
 @MainActor
 enum ProgressAnimationTracker {
     private static var progressMap: [PersistentIdentifier: Double] = [:]
+    private static var titleMap: [PersistentIdentifier: String] = [:]
+    private static var deadlineMap: [PersistentIdentifier: Date?] = [:]
+    private static var goalMap: [PersistentIdentifier: Int] = [:]
     private static var observer: NSObjectProtocol?
 
     static func lastProgress(for project: WritingProject) -> Double? {
@@ -17,12 +20,48 @@ enum ProgressAnimationTracker {
         progressMap[project.id] = value
     }
 
+    static func lastTitle(for project: WritingProject) -> String? {
+        titleMap[project.id]
+    }
+
+    static func setTitle(_ value: String, for project: WritingProject) {
+        titleMap[project.id] = value
+    }
+
+    static func lastDeadline(for project: WritingProject) -> Date? {
+        if let value = deadlineMap[project.id] {
+            return value
+        }
+        return nil
+    }
+
+    static func setDeadline(_ value: Date?, for project: WritingProject) {
+        deadlineMap[project.id] = value
+    }
+
+    static func lastGoal(for project: WritingProject) -> Int? {
+        goalMap[project.id]
+    }
+
+    static func setGoal(_ value: Int, for project: WritingProject) {
+        goalMap[project.id] = value
+    }
+
+    static func updateAttributes(for project: WritingProject) {
+        setTitle(project.title, for: project)
+        setDeadline(project.deadline, for: project)
+        setGoal(project.goal, for: project)
+    }
+
     /// Подготавливает трекер, сбрасывая стартовый прогресс до нуля и
     /// подписываясь на уведомления об изменении прогресса.
     static func initialize(with projects: [WritingProject]) {
         if progressMap.isEmpty {
-            projects.forEach { setProgress(0, for: $0) }
+            projects.forEach {
+                setProgress(0, for: $0)
+            }
         }
+        projects.forEach { updateAttributes(for: $0) }
         guard observer == nil else { return }
         observer = NotificationCenter.default.addObserver(forName: .projectProgressChanged,
                                                          object: nil,

--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -74,6 +74,8 @@ struct ProgressCircleView: View {
     /// При значении `true` прогресс сохраняется через ``ProgressAnimationTracker``.
     /// Это нужно, чтобы запускать анимацию при возврате к списку проектов.
     var trackProgress: Bool = true
+    /// Выбран ли сейчас этот проект
+    var isSelected: Bool = false
     /// Визуальный стиль круга прогресса
     var style: ProgressCircleStyle = .regular
 
@@ -231,6 +233,7 @@ struct ProgressCircleView: View {
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
+            ProgressAnimationTracker.updateAttributes(for: project)
         }
         .onDisappear { isVisible = false }
         .onChange(of: progress) { newValue in
@@ -271,31 +274,43 @@ struct ProgressCircleView: View {
                 lastProgress = progress
             }
         }
-        .onChange(of: project.title) { _ in
-            if trackProgress {
+        .onChange(of: project.title) { newValue in
+            if let old = ProgressAnimationTracker.lastTitle(for: project), old == newValue { return }
+            ProgressAnimationTracker.setTitle(newValue, for: project)
+            if trackProgress && isSelected {
                 ProgressAnimationTracker.setProgress(progress, for: project)
+                startProgress = progress
+                endProgress = progress
+                lastProgress = progress
+                if isVisible {
+                    updateProgress(to: progress, animated: false)
+                }
             }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
         }
-        .onChange(of: project.deadline) { _ in
-            if trackProgress {
+        .onChange(of: project.deadline) { newValue in
+            if let old = ProgressAnimationTracker.lastDeadline(for: project), old == newValue { return }
+            ProgressAnimationTracker.setDeadline(newValue, for: project)
+            if trackProgress && isSelected {
                 ProgressAnimationTracker.setProgress(progress, for: project)
+                startProgress = progress
+                endProgress = progress
+                lastProgress = progress
+                if isVisible {
+                    updateProgress(to: progress, animated: false)
+                }
             }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
         }
-        .onChange(of: project.goal) { _ in
-            if trackProgress {
+        .onChange(of: project.goal) { newValue in
+            if let old = ProgressAnimationTracker.lastGoal(for: project), old == newValue { return }
+            ProgressAnimationTracker.setGoal(newValue, for: project)
+            if trackProgress && isSelected {
                 ProgressAnimationTracker.setProgress(0, for: project)
-            }
-            startProgress = 0
-            endProgress = 0
-            lastProgress = 0
-            if isVisible {
-                DispatchQueue.main.async { updateProgress(to: progress) }
+                startProgress = 0
+                endProgress = 0
+                lastProgress = 0
+                if isVisible {
+                    DispatchQueue.main.async { updateProgress(to: progress) }
+                }
             }
         }
     }

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -71,7 +71,7 @@ struct ProjectDetailView: View {
     private var progressCircleSection: some View {
         HStack {
             Spacer()
-            ProgressCircleView(project: project, trackProgress: false, style: .large)
+            ProgressCircleView(project: project, trackProgress: false, isSelected: true, style: .large)
                 .id(project.id)
                 .frame(width: circleSize, height: circleSize)
             Spacer()
@@ -568,6 +568,7 @@ struct ProjectDetailView: View {
                 DocumentSyncManager.startMonitoring(project: project)
             }
 #endif
+            ProgressAnimationTracker.updateAttributes(for: project)
         }
         .onReceive(NotificationCenter.default.publisher(for: .menuAddEntry)) { _ in
             addEntry()
@@ -607,17 +608,23 @@ struct ProjectDetailView: View {
                 saveContext()
             }
         }
-        .onChange(of: project.title) { _ in
+        .onChange(of: project.title) { newValue in
+            if let old = ProgressAnimationTracker.lastTitle(for: project), old == newValue { return }
+            ProgressAnimationTracker.setTitle(newValue, for: project)
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(project.progress, for: project)
 #endif
         }
-        .onChange(of: project.deadline) { _ in
+        .onChange(of: project.deadline) { newValue in
+            if let old = ProgressAnimationTracker.lastDeadline(for: project), old == newValue { return }
+            ProgressAnimationTracker.setDeadline(newValue, for: project)
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(project.progress, for: project)
 #endif
         }
-        .onChange(of: project.goal) { _ in
+        .onChange(of: project.goal) { newValue in
+            if let old = ProgressAnimationTracker.lastGoal(for: project), old == newValue { return }
+            ProgressAnimationTracker.setGoal(newValue, for: project)
 #if canImport(SwiftData)
             ProgressAnimationTracker.setProgress(0, for: project)
             goalChanged = true

--- a/nfprogress/ProjectListViews.swift
+++ b/nfprogress/ProjectListViews.swift
@@ -10,6 +10,8 @@ struct ProjectPercentView: View {
     var index: Int = 0
     /// Общее число проектов в списке для подстройки задержки запуска анимации
     var totalCount: Int = 1
+    /// Выбран ли сейчас этот проект
+    var isSelected: Bool = false
 
     @AppStorage("disableLaunchAnimations") private var disableLaunchAnimations = false
     @AppStorage("disableAllAnimations") private var disableAllAnimations = false
@@ -97,6 +99,7 @@ struct ProjectPercentView: View {
                 }
             }
             ProgressAnimationTracker.setProgress(progress, for: project)
+            ProgressAnimationTracker.updateAttributes(for: project)
         }
         .onDisappear { isVisible = false }
         .onChange(of: progress) { newValue in
@@ -125,20 +128,30 @@ struct ProjectPercentView: View {
                 }
             }
         }
-        .onChange(of: project.title) { _ in
-            if isVisible {
+        .onChange(of: project.title) { newValue in
+            if let old = ProgressAnimationTracker.lastTitle(for: project), old == newValue { return }
+            ProgressAnimationTracker.setTitle(newValue, for: project)
+            if isVisible && isSelected {
                 ProgressAnimationTracker.setProgress(progress, for: project)
+                startProgress = progress
+                endProgress = progress
                 updateProgress(to: progress, animated: false)
             }
         }
-        .onChange(of: project.deadline) { _ in
-            if isVisible {
+        .onChange(of: project.deadline) { newValue in
+            if let old = ProgressAnimationTracker.lastDeadline(for: project), old == newValue { return }
+            ProgressAnimationTracker.setDeadline(newValue, for: project)
+            if isVisible && isSelected {
                 ProgressAnimationTracker.setProgress(progress, for: project)
+                startProgress = progress
+                endProgress = progress
                 updateProgress(to: progress, animated: false)
             }
         }
-        .onChange(of: project.goal) { _ in
-            if isVisible {
+        .onChange(of: project.goal) { newValue in
+            if let old = ProgressAnimationTracker.lastGoal(for: project), old == newValue { return }
+            ProgressAnimationTracker.setGoal(newValue, for: project)
+            if isVisible && isSelected {
                 ProgressAnimationTracker.setProgress(0, for: project)
                 startProgress = 0
                 endProgress = 0
@@ -155,13 +168,14 @@ struct CompactProjectRow: View {
     var project: WritingProject
     var index: Int
     var totalCount: Int
+    var isSelected: Bool
     var body: some View {
         HStack {
             Text(project.title)
                 .font(.headline)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
-            ProjectPercentView(project: project, index: index, totalCount: totalCount)
+            ProjectPercentView(project: project, index: index, totalCount: totalCount, isSelected: isSelected)
                 .id(project.id)
         }
         .padding(.vertical, scaledSpacing(1))


### PR DESCRIPTION
## Summary
- prevent animation restart when editing project title or deadline
- keep progress ring state consistent for the selected project

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_68629a88e8c88333b8043e2faea01faa