### PR TITLE
Remove progress animations on title change

### DIFF
--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -282,16 +282,14 @@ struct ProgressCircleView: View {
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
-            startProgress = progress
-            endProgress = progress
+            updateProgress(to: progress, animated: false)
             lastProgress = progress
         }
         .onChange(of: project.deadline) { _ in
             if trackProgress {
                 ProgressAnimationTracker.setProgress(progress, for: project)
             }
-            startProgress = progress
-            endProgress = progress
+            updateProgress(to: progress, animated: false)
             lastProgress = progress
         }
     }

--- a/nfprogress/ProjectTitleBar.swift
+++ b/nfprogress/ProjectTitleBar.swift
@@ -41,9 +41,9 @@ struct ProjectTitleBar: View {
 
     private func save() {
         isEditing = false
-        #if canImport(SwiftData)
+#if canImport(SwiftData)
         ProgressAnimationTracker.setProgress(project.progress, for: project)
-        #endif
+#endif
         do {
             try modelContext.save()
         } catch {


### PR DESCRIPTION
## Summary
- stop progress animation when editing project title or deadline
- remove stage title/deadline progress updates

## Testing
- `swift test --enable-test-discovery`


------
https://chatgpt.com/codex/tasks/task_e_6862ffbb0e74833380034c4f3d6a2727