### PR TITLE
Remove progress animations on title change

### DIFF
--- a/nfprogress/ProgressViews.swift
+++ b/nfprogress/ProgressViews.swift
@@ -278,22 +278,8 @@ struct ProgressCircleView: View {
                 lastProgress = progress
             }
         }
-        .onChange(of: project.title) { _ in
-            if trackProgress {
-                ProgressAnimationTracker.setProgress(progress, for: project)
-            }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
-        }
-        .onChange(of: project.deadline) { _ in
-            if trackProgress {
-                ProgressAnimationTracker.setProgress(progress, for: project)
-            }
-            startProgress = progress
-            endProgress = progress
-            lastProgress = progress
-        }
+        // Название и дедлайн проекта не влияют на прогресс,
+        // поэтому игнорируем их изменения
     }
 }
 

--- a/nfprogress/ProjectListViews.swift
+++ b/nfprogress/ProjectListViews.swift
@@ -128,18 +128,8 @@ struct ProjectPercentView: View {
                 }
             }
         }
-        .onChange(of: project.title) { _ in
-            if isVisible {
-                ProgressAnimationTracker.setProgress(progress, for: project)
-                updateProgress(to: progress, animated: false)
-            }
-        }
-        .onChange(of: project.deadline) { _ in
-            if isVisible {
-                ProgressAnimationTracker.setProgress(progress, for: project)
-                updateProgress(to: progress, animated: false)
-            }
-        }
+        // Изменения названия и дедлайна проекта не влияют на прогресс,
+        // поэтому не обновляем его и не запускаем анимацию
     }
 }
 

--- a/nfprogress/ProjectTitleBar.swift
+++ b/nfprogress/ProjectTitleBar.swift
@@ -41,9 +41,7 @@ struct ProjectTitleBar: View {
 
     private func save() {
         isEditing = false
-        #if canImport(SwiftData)
-        ProgressAnimationTracker.setProgress(project.progress, for: project)
-        #endif
+        // Изменение названия проекта не должно влиять на прогресс
         do {
             try modelContext.save()
         } catch {


### PR DESCRIPTION
## Summary
- stop progress animation when editing project title or deadline
- remove stage title/deadline progress updates

## Testing
- `swift test --enable-test-discovery`


------
https://chatgpt.com/codex/tasks/task_e_6862ffbb0e74833380034c4f3d6a2727