### PR TITLE
Fix Word char counting

### DIFF
--- a/nfprogress/DocumentSyncManager.swift
+++ b/nfprogress/DocumentSyncManager.swift
@@ -338,7 +338,7 @@ enum DocumentSyncManager {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
               let modDate = attrs[.modificationDate] as? Date else { return }
         guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
-        let totalCount = attrString.string.count // абсолютное количество символов в файле
+        let totalCount = attrString.string.utf16.count // абсолютное количество символов в файле
         if project.lastWordCharacters != totalCount || project.lastWordModified != modDate {
             let delta = computeDelta(totalCount: totalCount,
                                   last: project.lastWordCharacters,
@@ -454,7 +454,7 @@ enum DocumentSyncManager {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
               let modDate = attrs[.modificationDate] as? Date else { return }
         guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
-        let totalCount = attrString.string.count // абсолютное количество символов в файле
+        let totalCount = attrString.string.utf16.count // абсолютное количество символов в файле
         if stage.lastWordCharacters != totalCount || stage.lastWordModified != modDate {
             let delta = computeDelta(totalCount: totalCount,
                                   last: stage.lastWordCharacters,


### PR DESCRIPTION
## Summary
- use `.utf16.count` when reading Word files so the total character count matches Word

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_6863918c50908333ac3837a7b32d2370