### PR TITLE
Fix Word char count and Scrivener sync

### DIFF
--- a/nfprogress/DocumentSyncManager.swift
+++ b/nfprogress/DocumentSyncManager.swift
@@ -338,7 +338,8 @@ enum DocumentSyncManager {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
               let modDate = attrs[.modificationDate] as? Date else { return }
         guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
-        let totalCount = attrString.string.count // абсолютное количество символов в файле
+        let trimmed = attrString.string.trimmingCharacters(in: .newlines)
+        let totalCount = trimmed.utf16.count // абсолютное количество символов в файле
         if project.lastWordCharacters != totalCount || project.lastWordModified != modDate {
             let delta = computeDelta(totalCount: totalCount,
                                   last: project.lastWordCharacters,
@@ -454,7 +455,8 @@ enum DocumentSyncManager {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
               let modDate = attrs[.modificationDate] as? Date else { return }
         guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
-        let totalCount = attrString.string.count // абсолютное количество символов в файле
+        let trimmed = attrString.string.trimmingCharacters(in: .newlines)
+        let totalCount = trimmed.utf16.count // абсолютное количество символов в файле
         if stage.lastWordCharacters != totalCount || stage.lastWordModified != modDate {
             let delta = computeDelta(totalCount: totalCount,
                                   last: stage.lastWordCharacters,
@@ -503,10 +505,7 @@ enum DocumentSyncManager {
         guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
         let totalCount = attrString.string.count // абсолютное количество символов в файле
         if stage.lastScrivenerCharacters != totalCount || stage.lastScrivenerModified != modDate {
-            let delta = computeDelta(totalCount: totalCount,
-                                  last: stage.lastScrivenerCharacters,
-                                  current: stage.startProgress + stage.currentProgress)
-            let entry = Entry(date: modDate, characterCount: delta)
+            let entry = Entry(date: modDate, characterCount: totalCount)
             entry.syncSource = .scrivener
             stage.entries.append(entry)
             stage.lastScrivenerCharacters = totalCount
@@ -555,10 +554,7 @@ enum DocumentSyncManager {
         guard let attrString = try? NSAttributedString(url: url, options: [:], documentAttributes: nil) else { return }
         let totalCount = attrString.string.count // абсолютное количество символов в файле
         if project.lastScrivenerCharacters != totalCount || project.lastScrivenerModified != modDate {
-            let delta = computeDelta(totalCount: totalCount,
-                                  last: project.lastScrivenerCharacters,
-                                  current: project.currentProgress)
-            let entry = Entry(date: modDate, characterCount: delta)
+            let entry = Entry(date: modDate, characterCount: totalCount)
             entry.syncSource = .scrivener
             project.entries.append(entry)
             project.lastScrivenerCharacters = totalCount

--- a/nfprogress/Entry+Progress.swift
+++ b/nfprogress/Entry+Progress.swift
@@ -1,0 +1,19 @@
+#if canImport(SwiftData)
+import Foundation
+
+extension Sequence where Element == Entry {
+    /// Возвращает общий прогресс, корректно обрабатывая записи Scrivener,
+    /// которые содержат абсолютное значение символов.
+    func cumulativeProgress() -> Int {
+        var result = 0
+        for entry in self {
+            if entry.syncSource == .scrivener {
+                result = entry.characterCount
+            } else {
+                result += entry.characterCount
+            }
+        }
+        return result
+    }
+}
+#endif

--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -225,11 +225,11 @@ struct EditEntryView: View {
         if let stage = project.stageForEntry(entry) {
             let sorted = stage.sortedEntries.sorted { $0.date < $1.date }
             guard let idx = sorted.firstIndex(where: { $0.id == entry.id }) else { return entry.characterCount }
-            return sorted.prefix(idx + 1).reduce(0) { $0 + $1.characterCount }
+            return sorted.prefix(idx + 1).cumulativeProgress()
         } else {
             let sorted = project.entries.sorted { $0.date < $1.date }
             guard let idx = sorted.firstIndex(where: { $0.id == entry.id }) else { return entry.characterCount }
-            return sorted.prefix(idx + 1).reduce(0) { $0 + $1.characterCount }
+            return sorted.prefix(idx + 1).cumulativeProgress()
         }
     }
 
@@ -237,11 +237,11 @@ struct EditEntryView: View {
         if let stage = project.stageForEntry(entry) {
             let sorted = stage.sortedEntries.sorted { $0.date < $1.date }
             guard let idx = sorted.firstIndex(where: { $0.id == entry.id }) else { return 0 }
-            return sorted.prefix(idx).reduce(0) { $0 + $1.characterCount }
+            return sorted.prefix(idx).cumulativeProgress()
         } else {
             let sorted = project.entries.sorted { $0.date < $1.date }
             guard let idx = sorted.firstIndex(where: { $0.id == entry.id }) else { return 0 }
-            return sorted.prefix(idx).reduce(0) { $0 + $1.characterCount }
+            return sorted.prefix(idx).cumulativeProgress()
         }
     }
 

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -173,11 +173,12 @@ struct ProjectDetailView: View {
 
         private func entryRow(entry: Entry) -> some View {
             let index = stage.sortedEntries.firstIndex(where: { $0.id == entry.id }) ?? 0
-            let cumulative = stage.sortedEntries.prefix(index + 1).reduce(0) { $0 + $1.characterCount }
+            let cumulative = stage.sortedEntries.prefix(index + 1).cumulativeProgress()
             let clamped = max(cumulative, 0)
             let percent = Double(clamped) / Double(max(stage.goal, 1)) * 100
 
-            let delta = entry.characterCount
+            let previous = stage.sortedEntries.prefix(index).cumulativeProgress()
+            let delta = cumulative - previous
             let deltaPercent = Double(delta) / Double(max(stage.goal, 1)) * 100
 
             let isSelected = selectedEntry?.id == entry.id

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -63,7 +63,7 @@ class Stage: Identifiable {
     }
 
     var currentProgress: Int {
-        let total = sortedEntries.reduce(0) { $0 + $1.characterCount }
+        let total = sortedEntries.cumulativeProgress()
         return max(0, total)
     }
 

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -70,11 +70,7 @@ class WritingProject {
     func globalProgress(for entry: Entry) -> Int {
         let entries = sortedEntries
         guard let index = entries.firstIndex(where: { $0.id == entry.id }) else { return 0 }
-
-        var progress = 0
-        for i in 0...index {
-            progress += entries[i].characterCount
-        }
+        let progress = entries.prefix(index + 1).cumulativeProgress()
         return progress
     }
 
@@ -87,19 +83,19 @@ class WritingProject {
     }
 
     var currentProgress: Int {
-        let total = sortedEntries.reduce(0) { $0 + $1.characterCount }
+        let total = sortedEntries.cumulativeProgress()
         return max(0, total)
     }
 
     var previousProgress: Int {
         guard sortedEntries.count >= 2 else { return 0 }
         let prevEntries = sortedEntries.dropLast()
-        return prevEntries.reduce(0) { $0 + $1.characterCount }
+        return prevEntries.cumulativeProgress()
     }
 
     /// Сумма символов по всем этапам
     var totalStageCharacters: Int {
-        stages.flatMap(\.entries).reduce(0) { $0 + $1.characterCount }
+        stages.reduce(0) { $0 + $1.sortedEntries.cumulativeProgress() }
     }
 
     /// Общий прогресс проекта в диапазоне 0...1


### PR DESCRIPTION
## Summary
- strip trailing newlines when counting characters in Word files
- store absolute character count when syncing with Scrivener
- compute progress correctly when Scrivener entries contain totals

## Testing
- `swift test -c release`


------
https://chatgpt.com/codex/tasks/task_e_6863918c50908333ac3837a7b32d2370