### PR TITLE
Fix sync names display

### DIFF
--- a/nfprogress/DocumentSyncInfoView.swift
+++ b/nfprogress/DocumentSyncInfoView.swift
@@ -8,33 +8,52 @@ struct DocumentSyncInfoView: View {
     @EnvironmentObject private var settings: AppSettings
     @Bindable var project: WritingProject
 
-    private var info: String {
-        switch project.syncType {
-        case .word:
-            let path = DocumentSyncManager.resolvedPath(bookmark: project.wordFileBookmark,
-                                                        path: project.wordFilePath)
-            return settings.localized("sync_info_word", path ?? "")
-        case .scrivener:
-            let basePath = DocumentSyncManager.resolvedPath(bookmark: project.scrivenerProjectBookmark,
-                                                            path: project.scrivenerProjectPath)
-            var name = project.scrivenerItemID ?? ""
-            if let basePath, let itemID = project.scrivenerItemID {
-                let url = URL(fileURLWithPath: basePath)
-                let items = ScrivenerParser.items(in: url)
-                if let item = ScrivenerParser.findItem(withID: itemID, in: items) {
-                    name = item.title
-                }
+    private var wordPath: String? {
+        DocumentSyncManager.resolvedPath(bookmark: project.wordFileBookmark,
+                                         path: project.wordFilePath)
+    }
+
+    private var wordName: String? {
+        if let path = wordPath { return URL(fileURLWithPath: path).lastPathComponent }
+        return nil
+    }
+
+    private var scrivenerPath: String? {
+        DocumentSyncManager.resolvedPath(bookmark: project.scrivenerProjectBookmark,
+                                         path: project.scrivenerProjectPath)
+    }
+
+    private var scrivenerName: String {
+        if let title = project.scrivenerItemTitle { return title }
+        if let base = scrivenerPath, let itemID = project.scrivenerItemID {
+            let url = URL(fileURLWithPath: base)
+            url.startAccessingSecurityScopedResource()
+            defer { url.stopAccessingSecurityScopedResource() }
+            let items = ScrivenerParser.items(in: url)
+            if let item = ScrivenerParser.findItem(withID: itemID, in: items) {
+                project.scrivenerItemTitle = item.title
+                try? project.modelContext?.save()
+                return item.title
             }
-            return settings.localized("sync_info_scrivener", name, basePath ?? "")
-        case .none:
-            return ""
         }
+        return project.scrivenerItemID ?? ""
     }
 
     var body: some View {
         VStack(spacing: scaledSpacing()) {
-            Text(info)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            if project.syncType == .word {
+                Text(settings.localized("sync_word_label", wordName ?? ""))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let path = wordPath {
+                    Button(settings.localized("show_in_finder")) { showInFinder(path) }
+                }
+            } else if project.syncType == .scrivener {
+                Text(settings.localized("sync_scrivener_label", scrivenerName))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let path = scrivenerPath {
+                    Button(settings.localized("show_in_finder")) { showInFinder(path) }
+                }
+            }
             Toggle(settings.localized("pause_sync"), isOn: $project.syncPaused)
                 .toggleStyle(.switch)
                 .onChange(of: project.syncPaused) { value in
@@ -90,6 +109,11 @@ struct DocumentSyncInfoView: View {
             DocumentSyncManager.startMonitoring(project: project)
             dismiss()
         }
+    }
+
+    private func showInFinder(_ path: String) {
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 }
 #endif

--- a/nfprogress/DocumentSyncManager.swift
+++ b/nfprogress/DocumentSyncManager.swift
@@ -249,9 +249,16 @@ enum DocumentSyncManager {
                isScrivenerItemInUse(projectPath: base.path, itemID: itemID, excludingProject: id) {
                 return
             }
-            project.scrivenerProjectPath = base.path
             base.startAccessingSecurityScopedResource()
             accessURLs[id] = base
+            if project.scrivenerItemTitle == nil, let itemID = project.scrivenerItemID {
+                let items = ScrivenerParser.items(in: base)
+                if let item = ScrivenerParser.findItem(withID: itemID, in: items) {
+                    project.scrivenerItemTitle = item.title
+                    try? DataController.mainContext.save()
+                }
+            }
+            project.scrivenerProjectPath = base.path
             guard let path = scrivenerFilePath(for: project, baseURL: base) else {
                 stopMonitoring(project: project)
                 return
@@ -297,6 +304,7 @@ enum DocumentSyncManager {
         mainProject.scrivenerProjectPath = nil
         mainProject.scrivenerProjectBookmark = nil
         mainProject.scrivenerItemID = nil
+        mainProject.scrivenerItemTitle = nil
         mainProject.lastWordCharacters = nil
         mainProject.lastWordModified = nil
         mainProject.lastScrivenerCharacters = nil
@@ -377,9 +385,16 @@ enum DocumentSyncManager {
                isScrivenerItemInUse(projectPath: base.path, itemID: itemID, excludingStage: id) {
                 return
             }
-            stage.scrivenerProjectPath = base.path
             base.startAccessingSecurityScopedResource()
             stageAccessURLs[id] = base
+            if stage.scrivenerItemTitle == nil, let itemID = stage.scrivenerItemID {
+                let items = ScrivenerParser.items(in: base)
+                if let item = ScrivenerParser.findItem(withID: itemID, in: items) {
+                    stage.scrivenerItemTitle = item.title
+                    try? DataController.mainContext.save()
+                }
+            }
+            stage.scrivenerProjectPath = base.path
             guard let path = scrivenerFilePath(for: stage, baseURL: base) else {
                 stopMonitoring(stage: stage)
                 return
@@ -424,6 +439,7 @@ enum DocumentSyncManager {
         mainStage.scrivenerProjectPath = nil
         mainStage.scrivenerProjectBookmark = nil
         mainStage.scrivenerItemID = nil
+        mainStage.scrivenerItemTitle = nil
         mainStage.lastWordCharacters = nil
         mainStage.lastWordModified = nil
         mainStage.lastScrivenerCharacters = nil

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -106,6 +106,9 @@
 "toolbar_customization" = "Allow toolbar customization";
 "customize_toolbar" = "Customize Toolbar…";
 "change" = "Change";
+"sync_word_label" = "Word file %@";
+"sync_scrivener_label" = "Scrivener item %@";
+"show_in_finder" = "Show in Finder";
 "sync_interval_prefix" = "Check every";
 "sync_interval_suffix" = "seconds";
 "sync_now_button" = "Synchronize";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -107,6 +107,9 @@
 "toolbar_customization" = "Разрешить настройку панели";
 "customize_toolbar" = "Настроить панель инструментов…";
 "change" = "Изменить";
+"sync_word_label" = "Файл Word %@";
+"sync_scrivener_label" = "Элемент Scrivener %@";
+"show_in_finder" = "Показать в Finder";
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";
 "sync_now_button" = "Синхронизация";

--- a/nfprogress/ScrivenerItemSelectView.swift
+++ b/nfprogress/ScrivenerItemSelectView.swift
@@ -56,6 +56,7 @@ struct ScrivenerItemSelectView: View {
         project.scrivenerProjectPath = projectURL.path
         project.scrivenerProjectBookmark = try? projectURL.bookmarkData(options: .withSecurityScope)
         project.scrivenerItemID = item.id
+        project.scrivenerItemTitle = item.title
         try? project.modelContext?.save()
         DocumentSyncManager.startMonitoring(project: project)
         dismiss()

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -22,6 +22,8 @@ class Stage: Identifiable {
     var scrivenerProjectBookmark: Data?
     /// ID выбранного элемента Scrivener
     var scrivenerItemID: String?
+    /// Название выбранного элемента Scrivener
+    var scrivenerItemTitle: String?
     /// Последнее известное количество символов в Word
     var lastWordCharacters: Int?
     /// Последняя дата изменения Word
@@ -45,6 +47,7 @@ class Stage: Identifiable {
         self.scrivenerProjectPath = nil
         self.scrivenerProjectBookmark = nil
         self.scrivenerItemID = nil
+        self.scrivenerItemTitle = nil
         self.lastWordCharacters = nil
         self.lastWordModified = nil
         self.lastScrivenerCharacters = nil

--- a/nfprogress/StageScrivenerItemSelectView.swift
+++ b/nfprogress/StageScrivenerItemSelectView.swift
@@ -56,6 +56,7 @@ struct StageScrivenerItemSelectView: View {
         stage.scrivenerProjectPath = projectURL.path
         stage.scrivenerProjectBookmark = try? projectURL.bookmarkData(options: .withSecurityScope)
         stage.scrivenerItemID = item.id
+        stage.scrivenerItemTitle = item.title
         try? stage.modelContext?.save()
         DocumentSyncManager.startMonitoring(stage: stage)
         dismiss()

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -25,6 +25,8 @@ class WritingProject {
     var scrivenerProjectBookmark: Data?
     /// Выбранный ID элемента Scrivener
     var scrivenerItemID: String?
+    /// Название выбранного элемента Scrivener
+    var scrivenerItemTitle: String?
     /// Приостановлена ли синхронизация
     var syncPaused: Bool = false
     /// Количество символов в файле при последней проверке
@@ -44,6 +46,7 @@ class WritingProject {
         self.stages = []
         self.order = order
         self.isChartCollapsed = isChartCollapsed
+        self.scrivenerItemTitle = nil
         self.syncPaused = false
     }
 


### PR DESCRIPTION
## Summary
- ensure localized strings are formatted with arguments in sync info views

## Testing
- `swift test -c release`


------
https://chatgpt.com/codex/tasks/task_e_68639890f9b0833386a042e1f45b58bc