### PR TITLE
Add stage drag-and-drop reordering

### DIFF
--- a/nfprogress/CSVManager.swift
+++ b/nfprogress/CSVManager.swift
@@ -125,7 +125,7 @@ struct CSVManager {
                     stage = existing
                 } else {
                     let stageDeadline = dateFormatter.date(from: stageDeadlineStr)
-                    let newStage = Stage(title: stageTitle, goal: stageGoal, deadline: stageDeadline, startProgress: stageStart)
+                    let newStage = Stage(title: stageTitle, goal: stageGoal, deadline: stageDeadline, startProgress: stageStart, order: project.stages.count)
                     project.stages.append(newStage)
                     stage = newStage
                 }
@@ -155,6 +155,7 @@ struct CSVManager {
         var goal: Int
         var deadline: Date?
         var startProgress: Int
+        var order: Int
         var entries: [JSONEntry]
     }
 
@@ -176,12 +177,13 @@ struct CSVManager {
             deadline: project.deadline,
             lastShareProgress: project.lastShareProgress,
             entries: project.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) },
-            stages: project.stages.map { stage in
+            stages: project.stages.enumerated().map { idx, stage in
                 JSONStage(
                     title: stage.title,
                     goal: stage.goal,
                     deadline: stage.deadline,
                     startProgress: stage.startProgress,
+                    order: stage.order,
                     entries: stage.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) }
                 )
             }
@@ -196,10 +198,10 @@ struct CSVManager {
             let proj = WritingProject(title: jp.title, goal: jp.goal, deadline: jp.deadline, order: idx)
             proj.entries = jp.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
             proj.stages = jp.stages.map { js in
-                let st = Stage(title: js.title, goal: js.goal, deadline: js.deadline, startProgress: js.startProgress)
+                let st = Stage(title: js.title, goal: js.goal, deadline: js.deadline, startProgress: js.startProgress, order: js.order)
                 st.entries = js.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
                 return st
-            }
+            }.sorted { $0.order < $1.order }
             proj.lastShareProgress = jp.lastShareProgress
             return proj
         }

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -26,6 +26,7 @@ struct ProjectDetailView: View {
     @State private var stageToDelete: Stage?
     @State private var tempDeadline: Date = Date()
     @State private var selectedEntry: Entry?
+    @State private var draggedStage: Stage?
     // Состояние редактирования отдельных полей
     @State private var isEditingGoal = false
     @State private var isEditingDeadline = false
@@ -108,6 +109,16 @@ struct ProjectDetailView: View {
         if !project.stages.isEmpty {
             ForEach(project.stages) { stage in
                 stageDisclosureView(for: stage)
+                    .onDrag {
+                        draggedStage = stage
+                        return NSItemProvider(object: NSString(string: stage.title))
+                    }
+                    .onDrop(of: [.text], delegate: StageDropDelegate(
+                        target: stage,
+                        draggedItem: $draggedStage,
+                        stages: project.stages.sorted { $0.order < $1.order },
+                        moveAction: moveStages
+                    ))
             }
         }
     }
@@ -659,10 +670,21 @@ struct ProjectDetailView: View {
         stage.entries.removeAll()
         if let index = project.stages.firstIndex(where: { $0.id == stage.id }) {
             project.stages.remove(at: index)
+            for (idx, st) in project.stages.enumerated() {
+                st.order = idx
+            }
         }
         modelContext.delete(stage)
         saveContext()
         NotificationCenter.default.post(name: .projectProgressChanged, object: project.id)
+    }
+
+    private func moveStages(from source: IndexSet, to destination: Int) {
+        project.stages.move(fromOffsets: source, toOffset: destination)
+        for (index, stage) in project.stages.enumerated() {
+            stage.order = index
+        }
+        try? modelContext.save()
     }
 
     // MARK: - Sheet Modifier
@@ -698,6 +720,26 @@ struct ProjectDetailView: View {
                     EditStageView(stage: stage, project: project)
                 }
 #endif
+        }
+    }
+
+    private struct StageDropDelegate: DropDelegate {
+        let target: Stage
+        @Binding var draggedItem: Stage?
+        let stages: [Stage]
+        let moveAction: (IndexSet, Int) -> Void
+
+        func dropEntered(info: DropInfo) {
+            guard let dragged = draggedItem,
+                  dragged != target,
+                  let from = stages.firstIndex(where: { $0.id == dragged.id }),
+                  let to = stages.firstIndex(where: { $0.id == target.id }) else { return }
+            moveAction(IndexSet(integer: from), to > from ? to + 1 : to)
+        }
+
+        func performDrop(info: DropInfo) -> Bool {
+            draggedItem = nil
+            return true
         }
     }
 }

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -9,6 +9,8 @@ class Stage: Identifiable {
     var goal: Int
     var deadline: Date?
     var startProgress: Int
+    /// Порядок этапа в списке
+    var order: Int = 0
     var entries: [Entry]
     /// Тип синхронизации документа для этапа
     var syncType: SyncDocumentType?
@@ -35,11 +37,12 @@ class Stage: Identifiable {
     /// Приостановлена ли синхронизация
     var syncPaused: Bool = false
 
-    init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int) {
+    init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int, order: Int = 0) {
         self.title = title
         self.goal = goal
         self.deadline = deadline
         self.startProgress = startProgress
+        self.order = order
         self.entries = []
         self.syncType = nil
         self.wordFilePath = nil

--- a/nfprogress/StageViews.swift
+++ b/nfprogress/StageViews.swift
@@ -55,7 +55,7 @@ struct AddStageView: View {
     private func addStage() {
         let name = title.isEmpty ? settings.localized("stage_placeholder") : title
         let start = (project.stages.isEmpty && !project.entries.isEmpty) ? 0 : project.currentProgress
-        let stage = Stage(title: name, goal: goal, startProgress: start)
+        let stage = Stage(title: name, goal: goal, startProgress: start, order: project.stages.count)
         let moveEntries = project.stages.isEmpty && !project.entries.isEmpty
         dismiss()
         DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- add `draggedStage` state to track drag operation
- implement `moveStages` helper to reorder project's stages
- support dropping with `StageDropDelegate`
- enable macOS drag-and-drop modifiers in stage list
- extend stage drag-and-drop to iOS
- add stage `order` field and persist order changes

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_6863bedc102883338072de5b0971772a