### PR TITLE
Fix stage deletion crash

### DIFF
--- a/nfprogress/CSVManager.swift
+++ b/nfprogress/CSVManager.swift
@@ -125,7 +125,7 @@ struct CSVManager {
                     stage = existing
                 } else {
                     let stageDeadline = dateFormatter.date(from: stageDeadlineStr)
-                    let newStage = Stage(title: stageTitle, goal: stageGoal, deadline: stageDeadline, startProgress: stageStart)
+                    let newStage = Stage(title: stageTitle, goal: stageGoal, deadline: stageDeadline, startProgress: stageStart, order: project.stages.count)
                     project.stages.append(newStage)
                     stage = newStage
                 }
@@ -155,6 +155,7 @@ struct CSVManager {
         var goal: Int
         var deadline: Date?
         var startProgress: Int
+        var order: Int
         var entries: [JSONEntry]
     }
 
@@ -176,12 +177,13 @@ struct CSVManager {
             deadline: project.deadline,
             lastShareProgress: project.lastShareProgress,
             entries: project.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) },
-            stages: project.stages.map { stage in
+            stages: project.stages.enumerated().map { idx, stage in
                 JSONStage(
                     title: stage.title,
                     goal: stage.goal,
                     deadline: stage.deadline,
                     startProgress: stage.startProgress,
+                    order: stage.order,
                     entries: stage.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) }
                 )
             }
@@ -196,10 +198,10 @@ struct CSVManager {
             let proj = WritingProject(title: jp.title, goal: jp.goal, deadline: jp.deadline, order: idx)
             proj.entries = jp.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
             proj.stages = jp.stages.map { js in
-                let st = Stage(title: js.title, goal: js.goal, deadline: js.deadline, startProgress: js.startProgress)
+                let st = Stage(title: js.title, goal: js.goal, deadline: js.deadline, startProgress: js.startProgress, order: js.order)
                 st.entries = js.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
                 return st
-            }
+            }.sorted { $0.order < $1.order }
             proj.lastShareProgress = jp.lastShareProgress
             return proj
         }

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -436,35 +436,37 @@ struct ContentView: View {
 
   @ViewBuilder
   private var mainContent: some View {
+    Group {
 #if os(iOS)
-    splitView
-      .environment(\.editMode, $editMode)
-      .fileExporter(
-        isPresented: $isExporting,
-        document: exportDocument,
-        contentType: .commaSeparatedText,
-        defaultFilename: exportFileName
-      ) { result in
-        if case .failure(let error) = result {
-          print("Export failed: \(error.localizedDescription)")
+      splitView
+        .environment(\.editMode, $editMode)
+        .fileExporter(
+          isPresented: $isExporting,
+          document: exportDocument,
+          contentType: .commaSeparatedText,
+          defaultFilename: exportFileName
+        ) { result in
+          if case .failure(let error) = result {
+            print("Export failed: \(error.localizedDescription)")
+          }
+          isExporting = false
         }
-        isExporting = false
-      }
-      .fileImporter(
-        isPresented: $isImporting,
-        allowedContentTypes: [.commaSeparatedText]
-      ) { result in
-        switch result {
-        case .success(let url):
-          importCSV(from: url)
-        case .failure(let error):
-          print("Import failed: \(error.localizedDescription)")
+        .fileImporter(
+          isPresented: $isImporting,
+          allowedContentTypes: [.commaSeparatedText]
+        ) { result in
+          switch result {
+          case .success(let url):
+            importCSV(from: url)
+          case .failure(let error):
+            print("Import failed: \(error.localizedDescription)")
+          }
+          isImporting = false
         }
-        isImporting = false
-      }
 #else
-    splitView
+      splitView
 #endif
+    }
 #if !os(macOS)
     .sheet(isPresented: $showingAddProject) {
       AddProjectView()

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -26,6 +26,8 @@ struct ProjectDetailView: View {
     @State private var stageToDelete: Stage?
     @State private var tempDeadline: Date = Date()
     @State private var selectedEntry: Entry?
+    @State private var draggedStage: Stage?
+    @State private var dropTargetStage: Stage?
     // Состояние редактирования отдельных полей
     @State private var isEditingGoal = false
     @State private var isEditingDeadline = false
@@ -106,8 +108,20 @@ struct ProjectDetailView: View {
             .fixedSize(horizontal: false, vertical: true)
         Button("add_stage") { addStage() }
         if !project.stages.isEmpty {
-            ForEach(project.stages) { stage in
+            ForEach(project.stages.sorted { $0.order < $1.order }) { stage in
                 stageDisclosureView(for: stage)
+                    .onDrag {
+                        draggedStage = stage
+                        dropTargetStage = nil
+                        return NSItemProvider(object: NSString(string: stage.title))
+                    }
+                    .onDrop(of: [.text], delegate: StageDropDelegate(
+                        target: stage,
+                        draggedItem: $draggedStage,
+                        lastTarget: $dropTargetStage,
+                        getStages: { project.stages.sorted { $0.order < $1.order } },
+                        moveAction: moveStages
+                    ))
             }
         }
     }
@@ -159,10 +173,12 @@ struct ProjectDetailView: View {
             VStack(alignment: .leading) {
                 HStack {
                     Button("add_entry_button") { addEntryAction(stage) }
+#if os(macOS)
                     Button("sync_now_button") {
                         DocumentSyncManager.syncNow(stage: stage)
                     }
                     .disabled(stage.syncType == nil)
+#endif
                     Spacer()
                 }
                 ForEach(stage.sortedEntries) { entry in
@@ -260,10 +276,12 @@ struct ProjectDetailView: View {
             HStack {
                 Button("add_entry_button") { addEntry() }
                     .keyboardShortcut("n", modifiers: .command)
+#if os(macOS)
                 Button("sync_now_button") {
                     DocumentSyncManager.syncNow(project: project)
                 }
                 .disabled(project.syncType == nil)
+#endif
                 Spacer()
             }
         }
@@ -659,10 +677,27 @@ struct ProjectDetailView: View {
         stage.entries.removeAll()
         if let index = project.stages.firstIndex(where: { $0.id == stage.id }) {
             project.stages.remove(at: index)
+            for (idx, st) in project.stages.enumerated() {
+                st.order = idx
+            }
+        }
+        // Удаляем возможную ссылку на удаляемый этап
+        if draggedStage?.id == stage.id {
+            draggedStage = nil
         }
         modelContext.delete(stage)
         saveContext()
         NotificationCenter.default.post(name: .projectProgressChanged, object: project.id)
+    }
+
+    private func moveStages(from source: IndexSet, to destination: Int) {
+        var updated = project.stages
+        updated.move(fromOffsets: source, toOffset: destination)
+        project.stages = updated
+        for (index, stage) in project.stages.enumerated() {
+            stage.order = index
+        }
+        try? modelContext.save()
     }
 
     // MARK: - Sheet Modifier
@@ -698,6 +733,40 @@ struct ProjectDetailView: View {
                     EditStageView(stage: stage, project: project)
                 }
 #endif
+        }
+    }
+
+    private struct StageDropDelegate: DropDelegate {
+        let target: Stage
+        @Binding var draggedItem: Stage?
+        @Binding var lastTarget: Stage?
+        /// Актуальный список этапов
+        var getStages: () -> [Stage]
+        /// Действие по перемещению этапов
+        let moveAction: (IndexSet, Int) -> Void
+
+        func dropEntered(info: DropInfo) {
+            if lastTarget?.id == target.id { return }
+            lastTarget = target
+
+            let stages = getStages()
+            guard let dragged = draggedItem,
+                  dragged != target,
+                  let from = stages.firstIndex(where: { $0.id == dragged.id }),
+                  let to = stages.firstIndex(where: { $0.id == target.id }) else { return }
+            // Перетаскиваемый этап должен занять позицию цели,
+            // смещая её и последующие элементы вниз
+            moveAction(IndexSet(integer: from), to)
+        }
+
+        func dropUpdated(info: DropInfo) -> DropProposal? {
+            DropProposal(operation: .move)
+        }
+
+        func performDrop(info: DropInfo) -> Bool {
+            draggedItem = nil
+            lastTarget = nil
+            return true
         }
     }
 }

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -9,6 +9,8 @@ class Stage: Identifiable {
     var goal: Int
     var deadline: Date?
     var startProgress: Int
+    /// Порядок этапа в списке
+    var order: Int = 0
     var entries: [Entry]
     /// Тип синхронизации документа для этапа
     var syncType: SyncDocumentType?
@@ -35,11 +37,12 @@ class Stage: Identifiable {
     /// Приостановлена ли синхронизация
     var syncPaused: Bool = false
 
-    init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int) {
+    init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int, order: Int = 0) {
         self.title = title
         self.goal = goal
         self.deadline = deadline
         self.startProgress = startProgress
+        self.order = order
         self.entries = []
         self.syncType = nil
         self.wordFilePath = nil
@@ -57,15 +60,18 @@ class Stage: Identifiable {
 
     /// Записи этого этапа без повторов
     private var uniqueEntries: [Entry] {
+        guard modelContext != nil else { return [] }
         var seen = Set<UUID>()
         return entries.filter { seen.insert($0.id).inserted }
     }
 
     var sortedEntries: [Entry] {
-        uniqueEntries.sorted { $0.date < $1.date }
+        guard modelContext != nil else { return [] }
+        return uniqueEntries.sorted { $0.date < $1.date }
     }
 
     var currentProgress: Int {
+        guard modelContext != nil else { return 0 }
         let total = sortedEntries.cumulativeProgress()
         return max(0, total)
     }


### PR DESCRIPTION
## Summary
- skip progress calculations for removed stage
- avoid accessing entries of deleted stage
- remember last drop target during drag to avoid reordering loops
- improve drop logic so dragged stage takes the target's position

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_6863bedc102883338072de5b0971772a