### PR TITLE
Добавлен счётчик символов в меню бара

### DIFF
--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -71,6 +71,7 @@ struct ContentView: View {
     }
   }
 
+
   private var splitView: some View {
 #if os(iOS)
     Group {
@@ -268,6 +269,7 @@ struct ContentView: View {
       .help(settings.localized("delete_project_tooltip"))
       .disabled(selectedProject == nil)
     }
+
   }
 
   // Кастомизируемые элементы панели
@@ -340,10 +342,10 @@ struct ContentView: View {
             }
             .help(settings.localized("toggle_view_tooltip"))
 
-            Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
-              Image(systemName: settings.projectSortOrder.iconName)
-            }
-            .help(settings.localized("toggle_sort_tooltip"))
+          Button { settings.projectSortOrder = settings.projectSortOrder.next } label: {
+            Image(systemName: settings.projectSortOrder.iconName)
+          }
+          .help(settings.localized("toggle_sort_tooltip"))
           }
         }
       }

--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -261,7 +261,10 @@ import SwiftData
 struct MenuBarEntryView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var settings: AppSettings
     @Query private var projects: [WritingProject]
+
+    @State private var progressToken = UUID()
 
     @State private var selectedIndex: Int = 0
     @State private var selectedStageIndex: Int = 0
@@ -285,6 +288,12 @@ struct MenuBarEntryView: View {
     private let fieldWidth: CGFloat = layoutStep(20)
     private let minWidth: CGFloat = layoutStep(25)
     private let minHeight: CGFloat = layoutStep(20)
+
+    /// Сумма символов, написанных сегодня во всех проектах
+    private var writtenToday: Int {
+        _ = progressToken
+        return projects.charactersWrittenToday()
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: viewSpacing) {
@@ -333,6 +342,9 @@ struct MenuBarEntryView: View {
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
             }
+            Text(settings.localized("written_today", writtenToday))
+                .monospacedDigit()
+                .font(.footnote)
         }
         .scaledPadding()
         .frame(minWidth: minWidth, minHeight: minHeight)
@@ -344,6 +356,9 @@ struct MenuBarEntryView: View {
         }
         .onChange(of: selectedIndex) { _ in
             selectedStageIndex = 0
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .projectProgressChanged)) { _ in
+            progressToken = UUID()
         }
     }
 

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -124,3 +124,4 @@
 "projects_imported_copies_marked" = "Projects imported, copies labeled separately";
 "import_success" = "Import completed successfully";
 "import_failed" = "Import failed";
+"written_today" = "Written today %d characters";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -125,3 +125,4 @@
 "projects_imported_copies_marked" = "Проекты импортированы, копии помечены отдельно";
 "import_success" = "Импорт успешно завершен";
 "import_failed" = "Импорт не состоялся";
+"written_today" = "Написано сегодня %d символов";

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -271,6 +271,20 @@ class WritingProject {
         return Int(Double(progressLastWeek) / Double(goal) * 100)
     }
 
+    /// Количество символов, добавленных сегодня во всех записях проекта
+    var charactersWrittenToday: Int {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+        let todayEntries = sortedEntries.filter { calendar.isDate($0.date, inSameDayAs: today) }
+        var total = 0
+        for entry in todayEntries {
+            let current = globalProgress(for: entry)
+            let previous = previousGlobalProgress(before: entry)
+            total += max(0, current - previous)
+        }
+        return total
+    }
+
     /// Соответствие ``Identifiable`` и ``Hashable`` позволяет
     /// использовать ``WritingProject`` в навигации.
 }
@@ -296,6 +310,13 @@ class Entry: Identifiable {
     init(date: Date, characterCount: Int) {
         self.date = date
         self.characterCount = characterCount
+    }
+}
+
+extension Sequence where Element == WritingProject {
+    /// Суммарное количество символов, написанных сегодня во всех проектах
+    func charactersWrittenToday() -> Int {
+        self.reduce(0) { $0 + $1.charactersWrittenToday }
     }
 }
 


### PR DESCRIPTION
## Изменения
- количество символов, написанных сегодня, отображается во всплывающем окне меню бара
- вычисление производится по всем проектам и автоматически обновляется при изменении записей

## Проверка
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_686bb6690ccc833382b2bc902bada162