### PR TITLE
Унификация кнопки синхронизации этапов

### DIFF
--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -106,7 +106,15 @@ struct ProjectDetailView: View {
         Text("stages")
             .font(.title3.bold())
             .fixedSize(horizontal: false, vertical: true)
-        Button("add_stage") { addStage() }
+        HStack {
+            Button("add_stage") { addStage() }
+#if os(macOS)
+            if project.hasStageSync {
+                Button("sync_now_button") { syncAllStages() }
+            }
+#endif
+            Spacer()
+        }
         if !project.stages.isEmpty {
             ForEach(project.stages.sorted { $0.order < $1.order }) { stage in
                 stageDisclosureView(for: stage)
@@ -173,12 +181,6 @@ struct ProjectDetailView: View {
             VStack(alignment: .leading) {
                 HStack {
                     Button("add_entry_button") { addEntryAction(stage) }
-#if os(macOS)
-                    Button("sync_now_button") {
-                        DocumentSyncManager.syncNow(stage: stage)
-                    }
-                    .disabled(stage.syncType == nil)
-#endif
                     Spacer()
                 }
                 ForEach(stage.sortedEntries) { entry in
@@ -472,6 +474,14 @@ struct ProjectDetailView: View {
         showingAddStage = true
         #endif
     }
+
+#if os(macOS)
+    private func syncAllStages() {
+        for stage in project.stages where stage.syncType != nil {
+            DocumentSyncManager.syncNow(stage: stage)
+        }
+    }
+#endif
 
     @ViewBuilder
     private var infoSection: some View {

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -112,7 +112,7 @@
 "show_in_finder" = "Показать в Finder";
 "sync_interval_prefix" = "Отслеживать изменения каждые";
 "sync_interval_suffix" = "секунд";
-"sync_now_button" = "Синхронизация";
+"sync_now_button" = "Синхронизировать";
 "deadline_reminders" = "Напоминания о дедлайнах";
 "reminder_time" = "Время отправки";
 "reminders_on_launch" = "Присылать напоминания при запуске";


### PR DESCRIPTION
## Summary
- move per-stage sync button to stage list header
- implement project-level sync for all synced stages
- update Russian localization

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_68702f8a8a4c83338a2ed5be00a38f4f