### PR TITLE
Добавление кнопки "Добавить запись" и правка выбора этапа

### DIFF
--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -319,8 +319,6 @@ struct MenuBarEntryView: View {
                 let project = projects[min(max(selectedIndex, 0), projects.count - 1)]
                 if !project.stages.isEmpty {
                     Picker("stage_picker", selection: $selectedStageIndex) {
-                        Text("no_stage")
-                            .tag(0)
                         ForEach(Array(project.stages.enumerated()), id: \.offset) { idx, stage in
                             Text(stage.title)
                                 .tag(idx + 1)
@@ -353,9 +351,15 @@ struct MenuBarEntryView: View {
         }
         .onAppear {
             didSave = false
+            if let project = projects.first, !project.stages.isEmpty {
+                selectedStageIndex = 1
+            } else {
+                selectedStageIndex = 0
+            }
         }
         .onChange(of: selectedIndex) { _ in
-            selectedStageIndex = 0
+            let project = projects[min(max(selectedIndex, 0), projects.count - 1)]
+            selectedStageIndex = project.stages.isEmpty ? 0 : 1
         }
         .onReceive(NotificationCenter.default.publisher(for: .projectProgressChanged)) { _ in
             progressToken = UUID()

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -107,6 +107,9 @@ struct ProjectDetailView: View {
             .font(.title3.bold())
             .fixedSize(horizontal: false, vertical: true)
         HStack {
+            if !project.stages.isEmpty {
+                Button("add_entry_button") { addEntry() }
+            }
             Button("add_stage") { addStage() }
 #if os(macOS)
             if project.hasStageSync {


### PR DESCRIPTION
## Summary
- add a unified "Add entry" button above stage list
- prevent adding entries without stage from menu bar picker

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687036c399dc8333aad07985c3fdf783