### PR TITLE
Fix cumulative progress for multi-stage projects

### DIFF
--- a/nfprogressTests/SyncProgressTests.swift
+++ b/nfprogressTests/SyncProgressTests.swift
@@ -48,5 +48,26 @@ final class SyncProgressTests: XCTestCase {
         XCTAssertEqual(total2, 75)
         XCTAssertEqual(total2 - total1, 25)
     }
+
+    func testProgressAcrossMultipleStages() {
+        let project = WritingProject(title: "Test", goal: 2000)
+        let stage1 = Stage(title: "Stage1", goal: 1000, deadline: nil, startProgress: 0)
+        let stage2 = Stage(title: "Stage2", goal: 1000, deadline: nil, startProgress: 0)
+        project.stages.append(stage1)
+        project.stages.append(stage2)
+
+        let date1 = Date()
+        let entry1 = Entry(date: date1, characterCount: 1000)
+        entry1.syncSource = .scrivener
+        stage1.entries.append(entry1)
+
+        let date2 = date1.addingTimeInterval(60)
+        let entry2 = Entry(date: date2, characterCount: 500)
+        entry2.syncSource = .scrivener
+        stage2.entries.append(entry2)
+
+        XCTAssertEqual(project.globalProgress(for: entry1), 1000)
+        XCTAssertEqual(project.globalProgress(for: entry2), 1500)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- correct calculation of overall project progress when stage entries come from Scrivener
- add regression test for multiple stages with Scrivener sync

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_68704456f58883339037fa43f32b544f