### PR TITLE
Add project and stage completion

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -77,6 +77,7 @@ final class AppSettings: ObservableObject {
         case progress
         case deadline
         case custom
+        case finished
         var id: String { rawValue }
 #if canImport(SwiftUI)
         var description: LocalizedStringKey {
@@ -85,6 +86,7 @@ final class AppSettings: ObservableObject {
             case .progress: return "sort_progress"
             case .deadline: return "sort_deadline"
             case .custom: return "sort_custom"
+            case .finished: return "sort_finished"
             }
         }
 #endif
@@ -95,6 +97,7 @@ final class AppSettings: ObservableObject {
             case .progress: return "chart.bar"
             case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
+            case .finished: return "checkmark"
             }
         }
 
@@ -103,7 +106,8 @@ final class AppSettings: ObservableObject {
             case .title: return .progress
             case .progress: return .deadline
             case .deadline: return .custom
-            case .custom: return .title
+            case .custom: return .finished
+            case .finished: return .title
             }
         }
     }
@@ -292,6 +296,7 @@ final class AppSettings {
         case progress
         case deadline
         case custom
+        case finished
 
         var description: String {
             switch self {
@@ -299,6 +304,7 @@ final class AppSettings {
             case .progress: return NSLocalizedString("sort_progress", comment: "")
             case .deadline: return NSLocalizedString("sort_deadline", comment: "")
             case .custom: return NSLocalizedString("sort_custom", comment: "")
+            case .finished: return NSLocalizedString("sort_finished", comment: "")
             }
         }
 
@@ -308,6 +314,7 @@ final class AppSettings {
             case .progress: return "chart.bar"
             case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
+            case .finished: return "checkmark"
             }
         }
 
@@ -316,7 +323,8 @@ final class AppSettings {
             case .title: return .progress
             case .progress: return .deadline
             case .deadline: return .custom
-            case .custom: return .title
+            case .custom: return .finished
+            case .finished: return .title
             }
         }
     }

--- a/nfprogress/CSVManager.swift
+++ b/nfprogress/CSVManager.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 struct CSVManager {
     static func csvString(for project: WritingProject) -> String {
-        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress"]
+        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress,ProjectFinished,StageFinished"]
         let dateFormatter = ISO8601DateFormatter()
         let deadlineString = project.deadline.map { dateFormatter.string(from: $0) } ?? ""
         var all: [(Entry, Stage?)] = project.entries.map { ($0, nil) }
@@ -18,7 +18,7 @@ struct CSVManager {
         }
         if all.isEmpty && emptyStages.isEmpty {
             let share = project.lastShareProgress.map(String.init) ?? ""
-            lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,,,\(share)")
+            lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,,,\(share),\(project.isFinished),")
         } else {
             let sorted = all.sorted { $0.0.date < $1.0.date }
             var cumulative = 0
@@ -33,19 +33,19 @@ struct CSVManager {
                 let stageDeadline = stage?.deadline.map { dateFormatter.string(from: $0) } ?? ""
                 let stageStart = stage != nil ? String(stage!.startProgress) : ""
                 let share = project.lastShareProgress.map(String.init) ?? ""
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share)")
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share),\(project.isFinished),\(stage?.isFinished ?? false)")
             }
             for stage in emptyStages {
                 let stageDeadline = stage.deadline.map { dateFormatter.string(from: $0) } ?? ""
                 let share = project.lastShareProgress.map(String.init) ?? ""
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share)")
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share),\(project.isFinished),\(stage.isFinished)")
             }
         }
         return lines.joined(separator: "\n")
     }
 
     static func csvString(for projects: [WritingProject]) -> String {
-        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress"]
+        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress,ProjectFinished,StageFinished"]
         let dateFormatter = ISO8601DateFormatter()
         for project in projects {
             let deadlineString = project.deadline.map { dateFormatter.string(from: $0) } ?? ""
@@ -75,12 +75,12 @@ struct CSVManager {
                     let stageDeadline = stage?.deadline.map { dateFormatter.string(from: $0) } ?? ""
                     let stageStart = stage != nil ? String(stage!.startProgress) : ""
                     let share = project.lastShareProgress.map(String.init) ?? ""
-                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share)")
+                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share),\(project.isFinished),\(stage?.isFinished ?? false)")
                 }
                 for stage in emptyStages {
                     let stageDeadline = stage.deadline.map { dateFormatter.string(from: $0) } ?? ""
                     let share = project.lastShareProgress.map(String.init) ?? ""
-                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share)")
+                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share),\(project.isFinished),\(stage.isFinished)")
                 }
             }
         }
@@ -106,6 +106,8 @@ struct CSVManager {
             let changeColumn = components.count > 9 ? Int(components[9]) : nil
             let count = changeColumn ?? countColumn
             let shareProgress = components.count > 11 ? Int(components[11]) : nil
+            let projectFinished = components.count > 12 ? (components[12].lowercased() == "true") : false
+            let stageFinished = components.count > 13 ? (components[13].lowercased() == "true") : false
 
             let project: WritingProject
             if let existing = projectsDict[title] {
@@ -118,6 +120,7 @@ struct CSVManager {
             if let shareProgress {
                 project.lastShareProgress = shareProgress
             }
+            project.isFinished = projectFinished
 
             var stage: Stage? = nil
             if !stageTitle.isEmpty {
@@ -129,6 +132,7 @@ struct CSVManager {
                     project.stages.append(newStage)
                     stage = newStage
                 }
+                stage?.isFinished = stageFinished
             }
 
             if let date = dateFormatter.date(from: dateStr) {
@@ -156,6 +160,7 @@ struct CSVManager {
         var deadline: Date?
         var startProgress: Int
         var order: Int
+        var isFinished: Bool?
         var entries: [JSONEntry]
     }
 
@@ -164,6 +169,7 @@ struct CSVManager {
         var goal: Int
         var deadline: Date?
         var lastShareProgress: Int?
+        var isFinished: Bool?
         var entries: [JSONEntry]
         var stages: [JSONStage]
     }
@@ -176,6 +182,7 @@ struct CSVManager {
             goal: project.goal,
             deadline: project.deadline,
             lastShareProgress: project.lastShareProgress,
+            isFinished: project.isFinished,
             entries: project.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) },
             stages: project.stages.enumerated().map { idx, stage in
                 JSONStage(
@@ -184,6 +191,7 @@ struct CSVManager {
                     deadline: stage.deadline,
                     startProgress: stage.startProgress,
                     order: stage.order,
+                    isFinished: stage.isFinished,
                     entries: stage.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) }
                 )
             }
@@ -200,9 +208,11 @@ struct CSVManager {
             proj.stages = jp.stages.map { js in
                 let st = Stage(title: js.title, goal: js.goal, deadline: js.deadline, startProgress: js.startProgress, order: js.order)
                 st.entries = js.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
+                st.isFinished = js.isFinished ?? false
                 return st
             }.sorted { $0.order < $1.order }
             proj.lastShareProgress = jp.lastShareProgress
+            proj.isFinished = jp.isFinished ?? false
             return proj
         }
     }

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -55,19 +55,22 @@ struct ContentView: View {
 
 
   private var sortedProjects: [WritingProject] {
+    let active = projects.filter { !$0.isFinished }
     switch settings.projectSortOrder {
     case .title:
-      return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
+      return active.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
-      return projects.sorted { $0.progress > $1.progress }
+      return active.sorted { $0.progress > $1.progress }
     case .deadline:
-      return projects.sorted {
+      return active.sorted {
         let d0 = $0.deadline == nil ? Int.max : $0.daysLeft
         let d1 = $1.deadline == nil ? Int.max : $1.daysLeft
         return d0 < d1
       }
     case .custom:
-      return projects
+      return active
+    case .finished:
+      return projects.filter { $0.isFinished }.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     }
   }
 

--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -16,24 +16,32 @@ struct AddEntryView: View {
     /// Текст, введённый пользователем для нового значения прогресса.
     @State private var characterText = ""
 
+    /// Стадии, доступные для добавления записей
+    private var availableStages: [Stage] {
+        project.sortedStages.filter { !$0.isFinished }
+    }
+
     /// Текущий прогресс выбранного этапа или всего проекта.
     private var previousProgress: Int {
         if let fixedStage {
             return fixedStage.currentProgress
         }
-        if project.sortedStages.isEmpty {
+        if availableStages.isEmpty {
             return project.currentProgress
         }
-        let stage = project.sortedStages[min(max(selectedStageIndex, 0), project.sortedStages.count - 1)]
+        let stage = availableStages[min(max(selectedStageIndex, 0), availableStages.count - 1)]
         return stage.currentProgress
     }
 
     init(project: WritingProject, stage: Stage? = nil) {
         self.project = project
         self.fixedStage = stage
+        // При инициализации `availableStages` ещё нельзя обращаться к `self`,
+        // поэтому используем локальный список стадий проекта
+        let stages = project.sortedStages.filter { !$0.isFinished }
         let initialIndex: Int
         if let stage,
-           let found = project.sortedStages.firstIndex(where: { $0.id == stage.id }) {
+           let found = stages.firstIndex(where: { $0.id == stage.id }) {
             initialIndex = found
         } else {
             initialIndex = 0
@@ -51,9 +59,9 @@ struct AddEntryView: View {
             DatePicker("date_time", selection: $date)
                 .labelsHidden()
 
-            if fixedStage == nil && !project.sortedStages.isEmpty {
+            if fixedStage == nil && !availableStages.isEmpty {
                 Picker("stage", selection: $selectedStageIndex) {
-                    ForEach(Array(project.sortedStages.enumerated()), id: \.offset) { idx, stage in
+                    ForEach(Array(availableStages.enumerated()), id: \.offset) { idx, stage in
                         Text(stage.title)
                             .tag(idx)
                     }
@@ -81,6 +89,7 @@ struct AddEntryView: View {
             .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
             .scaledPadding(1, .bottom)
+            .disabled(project.isFinished || fixedStage?.isFinished == true)
         }
         .scaledPadding(1, [.horizontal, .bottom])
         .scaledPadding(2, .top)
@@ -90,7 +99,7 @@ struct AddEntryView: View {
 #endif
         .onChange(of: selectedStageIndex) { newValue in
             guard fixedStage == nil,
-                  project.sortedStages.indices.contains(newValue) else { return }
+                  availableStages.indices.contains(newValue) else { return }
             characterText = ""
         }
     }
@@ -106,11 +115,13 @@ struct AddEntryView: View {
             if let fixedStage {
                 targetStage = fixedStage
             } else {
-                let index = min(max(selectedStageIndex, 0), project.sortedStages.count - 1)
-                targetStage = project.sortedStages[index]
+                let index = min(max(selectedStageIndex, 0), availableStages.count - 1)
+                targetStage = availableStages[index]
             }
             delta = entered - (targetStage?.currentProgress ?? 0)
         }
+
+        guard !project.isFinished, targetStage?.isFinished != true else { return }
 
         let newEntry = Entry(date: date, characterCount: delta)
         dismiss()

--- a/nfprogress/ImportExportView.swift
+++ b/nfprogress/ImportExportView.swift
@@ -164,6 +164,7 @@ struct ImportExportView: View {
                 current.entries = imported.entries
                 current.stages = imported.stages
                 current.lastShareProgress = imported.lastShareProgress
+                current.isFinished = imported.isFinished
 
                 for stage in current.stages {
                     if let old = stageSyncInfo[stage.title] {
@@ -178,6 +179,9 @@ struct ImportExportView: View {
                         stage.lastWordModified = old.lastWordModified
                         stage.lastScrivenerCharacters = old.lastScrivenerCharacters
                         stage.lastScrivenerModified = old.lastScrivenerModified
+                    }
+                    if let importedStage = imported.stages.first(where: { $0.title == stage.title }) {
+                        stage.isFinished = importedStage.isFinished
                     }
                 }
 

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -28,6 +28,7 @@ struct ProjectDetailView: View {
     @State private var selectedEntry: Entry?
     @State private var draggedStage: Stage?
     @State private var dropTargetStage: Stage?
+    @State private var showFinishAlert = false
     // Состояние редактирования отдельных полей
     @State private var isEditingGoal = false
     @State private var isEditingDeadline = false
@@ -109,8 +110,10 @@ struct ProjectDetailView: View {
         HStack {
             if !project.stages.isEmpty {
                 Button("add_entry_button") { addEntry() }
+                    .disabled(project.isFinished)
             }
             Button("add_stage") { addStage() }
+                .disabled(project.isFinished)
 #if os(macOS)
             if project.hasStageSync {
                 Button("sync_now_button") { syncAllStages() }
@@ -275,6 +278,7 @@ struct ProjectDetailView: View {
             HStack {
                 Button("add_entry_button") { addEntry() }
                     .keyboardShortcut("n", modifiers: .command)
+                    .disabled(project.isFinished)
 #if os(macOS)
                 Button("sync_now_button") {
                     DocumentSyncManager.syncNow(project: project)
@@ -597,6 +601,16 @@ struct ProjectDetailView: View {
         .onReceive(NotificationCenter.default.publisher(for: .menuAddStage)) { _ in
             addStage()
         }
+        .alert(settings.localized("finish_project_confirm"), isPresented: $showFinishAlert) {
+            Button(settings.localized("finish")) {
+                project.isFinished = true
+                try? modelContext.save()
+                NotificationCenter.default.post(name: .projectProgressChanged, object: project.id)
+            }
+            Button(settings.localized("cancel"), role: .cancel) { }
+        } message: {
+            Text("finish_project_message")
+        }
         .alert(item: $stageToDelete) { stage in
             if project.stages.count == 1 {
                 return Alert(
@@ -635,6 +649,16 @@ struct ProjectDetailView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 shareToolbarButton()
+            }
+            ToolbarItem(placement: .primaryAction) {
+                if project.isFinished {
+                    Text(settings.localized("finished_label"))
+                } else {
+                    Button(action: { showFinishAlert = true }) {
+                        Image(systemName: "checkmark")
+                    }
+                    .help(settings.localized("finish_project_tooltip"))
+                }
             }
 #if os(macOS)
             if !project.hasStageSync {

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -125,3 +125,10 @@
 "import_success" = "Import completed successfully";
 "import_failed" = "Import failed";
 "written_today" = "Written today %d characters";
+"finish_project_confirm" = "Finish this project?";
+"finish_project_message" = "After finishing it, you will only be able to view it.";
+"finish" = "Finish";
+"finish_project_tooltip" = "Finish project";
+"finish_stage_tooltip" = "Finish stage";
+"sort_finished" = "Finished";
+"finished_label" = "Finished";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -126,3 +126,10 @@
 "import_success" = "Импорт успешно завершен";
 "import_failed" = "Импорт не состоялся";
 "written_today" = "Написано сегодня %d символов";
+"finish_project_confirm" = "Вы хотите завершить проект?";
+"finish_project_message" = "После завершения его можно будет только просматривать";
+"finish" = "Завершить";
+"finish_project_tooltip" = "Завершить проект";
+"finish_stage_tooltip" = "Завершить этап";
+"sort_finished" = "Завершенные";
+"finished_label" = "Завершен";

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -36,6 +36,8 @@ class Stage: Identifiable {
     var lastScrivenerModified: Date?
     /// Приостановлена ли синхронизация
     var syncPaused: Bool = false
+    /// Завершён ли этап
+    var isFinished: Bool = false
 
     init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int, order: Int = 0) {
         self.title = title
@@ -73,11 +75,15 @@ class Stage: Identifiable {
     var currentProgress: Int {
         guard modelContext != nil else { return 0 }
         let total = sortedEntries.cumulativeProgress()
+        if isFinished {
+            return max(goal, total)
+        }
         return max(0, total)
     }
 
     var progressPercentage: Double {
         guard goal > 0 else { return 0 }
+        if isFinished { return 1.0 }
         let percent = Double(currentProgress) / Double(goal)
         return min(max(percent, 0), 1.0)
     }

--- a/nfprogress/StageViews.swift
+++ b/nfprogress/StageViews.swift
@@ -43,6 +43,7 @@ struct AddStageView: View {
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
                 .scaledPadding(1, .bottom)
+                .disabled(project.isFinished)
         }
         .scaledPadding(1, [.horizontal, .bottom])
         .scaledPadding(2, .top)
@@ -53,6 +54,7 @@ struct AddStageView: View {
     }
 
     private func addStage() {
+        guard !project.isFinished else { return }
         let name = title.isEmpty ? settings.localized("stage_placeholder") : title
         let start = (project.stages.isEmpty && !project.entries.isEmpty) ? 0 : project.currentProgress
         let stage = Stage(title: name, goal: goal, startProgress: start, order: project.stages.count)
@@ -106,10 +108,12 @@ struct EditStageView: View {
             TextField("project_name", text: $stage.title)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: fieldWidth)
+                .disabled(project.isFinished || stage.isFinished)
 
             TextField("project_goal", value: $stage.goal, format: .number)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: fieldWidth)
+                .disabled(project.isFinished || stage.isFinished)
 
             Spacer()
 
@@ -118,6 +122,7 @@ struct EditStageView: View {
             }
             .buttonStyle(.borderedProminent)
             .scaledPadding(1, .bottom)
+            .disabled(project.isFinished || stage.isFinished)
         }
         .scaledPadding()
         .frame(minWidth: minWidth, minHeight: minHeight)
@@ -149,6 +154,8 @@ struct StageHeaderView: View {
 #if os(macOS)
     @Environment(\.openWindow) private var openWindow
 #endif
+
+    @State private var showFinishAlert = false
 
     /// Значение прогресса в начале анимации
     @State private var startProgress: Double = 0
@@ -247,6 +254,14 @@ struct StageHeaderView: View {
             Button(action: onEdit) {
                 Image(systemName: "pencil")
             }
+            if stage.isFinished {
+                Image(systemName: "checkmark")
+            } else {
+                Button(action: { showFinishAlert = true }) {
+                    Image(systemName: "checkmark")
+                }
+                .help(settings.localized("finish_stage_tooltip"))
+            }
             Button(action: onDelete) {
                 Image(systemName: "trash")
             }
@@ -277,6 +292,16 @@ struct StageHeaderView: View {
             if let id = note.object as? PersistentIdentifier, id == project.id {
                 updateProgress(to: progress)
             }
+        }
+        .alert(settings.localized("finish_project_confirm"), isPresented: $showFinishAlert) {
+            Button(settings.localized("finish")) {
+                stage.isFinished = true
+                try? stage.modelContext?.save()
+                NotificationCenter.default.post(name: .projectProgressChanged, object: project.id)
+            }
+            Button(settings.localized("cancel"), role: .cancel) { }
+        } message: {
+            Text("finish_project_message")
         }
     }
 

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -37,6 +37,8 @@ class WritingProject {
     var lastScrivenerModified: Date?
     /// Прогресс в момент последнего шеринга
     var lastShareProgress: Int?
+    /// Завершён ли проект
+    var isFinished: Bool = false
 
     init(title: String, goal: Int, deadline: Date? = nil, order: Int = 0, isChartCollapsed: Bool = false) {
         self.title = title
@@ -109,8 +111,24 @@ class WritingProject {
     }
 
     var currentProgress: Int {
-        guard let last = sortedEntries.last else { return 0 }
-        return globalProgress(for: last)
+        let base: Int
+        if let last = sortedEntries.last {
+            base = globalProgress(for: last)
+        } else {
+            base = 0
+        }
+
+        let stageBonus = stages.reduce(0) { partial, stage in
+            guard stage.isFinished else { return partial }
+            let written = stage.sortedEntries.cumulativeProgress()
+            return partial + max(stage.goal - written, 0)
+        }
+
+        var total = base + stageBonus
+        if isFinished {
+            total = max(total, goal)
+        }
+        return total
     }
 
     var previousProgress: Int {
@@ -137,6 +155,7 @@ class WritingProject {
     /// Общий прогресс проекта в диапазоне 0...1
     var progress: Double {
         guard goal > 0 else { return 0 }
+        if isFinished { return 1.0 }
         return min(Double(currentProgress) / Double(goal), 1.0)
     }
 


### PR DESCRIPTION
## Summary
- add `isFinished` fields for projects and stages
- support sorting finished projects
- show finish buttons in project and stage views
- add completion alerts and disable editing when finished
- update import/export with finished status
- progress for finished items always 100%
- localize new strings
- fix compile error in `AddEntryView` initializer

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_6870f9044a808333973467f253b3d94d