### PR TITLE
Handle project completion fully

### DIFF
--- a/nfprogress/AppSettings.swift
+++ b/nfprogress/AppSettings.swift
@@ -77,6 +77,7 @@ final class AppSettings: ObservableObject {
         case progress
         case deadline
         case custom
+        case finished
         var id: String { rawValue }
 #if canImport(SwiftUI)
         var description: LocalizedStringKey {
@@ -85,6 +86,7 @@ final class AppSettings: ObservableObject {
             case .progress: return "sort_progress"
             case .deadline: return "sort_deadline"
             case .custom: return "sort_custom"
+            case .finished: return "sort_finished"
             }
         }
 #endif
@@ -95,6 +97,7 @@ final class AppSettings: ObservableObject {
             case .progress: return "chart.bar"
             case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
+            case .finished: return "checkmark"
             }
         }
 
@@ -103,7 +106,8 @@ final class AppSettings: ObservableObject {
             case .title: return .progress
             case .progress: return .deadline
             case .deadline: return .custom
-            case .custom: return .title
+            case .custom: return .finished
+            case .finished: return .title
             }
         }
     }
@@ -292,6 +296,7 @@ final class AppSettings {
         case progress
         case deadline
         case custom
+        case finished
 
         var description: String {
             switch self {
@@ -299,6 +304,7 @@ final class AppSettings {
             case .progress: return NSLocalizedString("sort_progress", comment: "")
             case .deadline: return NSLocalizedString("sort_deadline", comment: "")
             case .custom: return NSLocalizedString("sort_custom", comment: "")
+            case .finished: return NSLocalizedString("sort_finished", comment: "")
             }
         }
 
@@ -308,6 +314,7 @@ final class AppSettings {
             case .progress: return "chart.bar"
             case .deadline: return "calendar"
             case .custom: return "arrow.up.arrow.down"
+            case .finished: return "checkmark"
             }
         }
 
@@ -316,7 +323,8 @@ final class AppSettings {
             case .title: return .progress
             case .progress: return .deadline
             case .deadline: return .custom
-            case .custom: return .title
+            case .custom: return .finished
+            case .finished: return .title
             }
         }
     }

--- a/nfprogress/CSVManager.swift
+++ b/nfprogress/CSVManager.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 struct CSVManager {
     static func csvString(for project: WritingProject) -> String {
-        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress"]
+        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress,ProjectFinished,StageFinished,ProjectFinishDate,StageFinishDate"]
         let dateFormatter = ISO8601DateFormatter()
         let deadlineString = project.deadline.map { dateFormatter.string(from: $0) } ?? ""
         var all: [(Entry, Stage?)] = project.entries.map { ($0, nil) }
@@ -18,7 +18,8 @@ struct CSVManager {
         }
         if all.isEmpty && emptyStages.isEmpty {
             let share = project.lastShareProgress.map(String.init) ?? ""
-            lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,,,\(share)")
+            let projFinish = project.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+            lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),,,,,,,,\(share),\(project.isFinished),,\(projFinish),")
         } else {
             let sorted = all.sorted { $0.0.date < $1.0.date }
             var cumulative = 0
@@ -33,19 +34,23 @@ struct CSVManager {
                 let stageDeadline = stage?.deadline.map { dateFormatter.string(from: $0) } ?? ""
                 let stageStart = stage != nil ? String(stage!.startProgress) : ""
                 let share = project.lastShareProgress.map(String.init) ?? ""
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share)")
+                let projFinish = project.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                let stageFinish = stage?.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share),\(project.isFinished),\(stage?.isFinished ?? false),\(projFinish),\(stageFinish)")
             }
             for stage in emptyStages {
                 let stageDeadline = stage.deadline.map { dateFormatter.string(from: $0) } ?? ""
                 let share = project.lastShareProgress.map(String.init) ?? ""
-                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share)")
+                let projFinish = project.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                let stageFinish = stage.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share),\(project.isFinished),\(stage.isFinished),\(projFinish),\(stageFinish)")
             }
         }
         return lines.joined(separator: "\n")
     }
 
     static func csvString(for projects: [WritingProject]) -> String {
-        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress"]
+        var lines: [String] = ["Title,Goal,Deadline,Stage,StageGoal,StageDeadline,StageStart,Date,CharacterCount,ChangeSinceLast,ProgressPercent,LastShareProgress,ProjectFinished,StageFinished,ProjectFinishDate,StageFinishDate"]
         let dateFormatter = ISO8601DateFormatter()
         for project in projects {
             let deadlineString = project.deadline.map { dateFormatter.string(from: $0) } ?? ""
@@ -75,12 +80,16 @@ struct CSVManager {
                     let stageDeadline = stage?.deadline.map { dateFormatter.string(from: $0) } ?? ""
                     let stageStart = stage != nil ? String(stage!.startProgress) : ""
                     let share = project.lastShareProgress.map(String.init) ?? ""
-                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share)")
+                    let projFinish = project.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                    let stageFinish = stage?.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stageTitle)),\(stageGoal),\(stageDeadline),\(stageStart),\(dateStr),\(total),\(change),\(percent),\(share),\(project.isFinished),\(stage?.isFinished ?? false),\(projFinish),\(stageFinish)")
                 }
                 for stage in emptyStages {
                     let stageDeadline = stage.deadline.map { dateFormatter.string(from: $0) } ?? ""
                     let share = project.lastShareProgress.map(String.init) ?? ""
-                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share)")
+                    let projFinish = project.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                    let stageFinish = stage.finishDate.map { dateFormatter.string(from: $0) } ?? ""
+                    lines.append("\(escape(project.title)),\(project.goal),\(deadlineString),\(escape(stage.title)),\(stage.goal),\(stageDeadline),\(stage.startProgress),,,,,\(share),\(project.isFinished),\(stage.isFinished),\(projFinish),\(stageFinish)")
                 }
             }
         }
@@ -106,6 +115,12 @@ struct CSVManager {
             let changeColumn = components.count > 9 ? Int(components[9]) : nil
             let count = changeColumn ?? countColumn
             let shareProgress = components.count > 11 ? Int(components[11]) : nil
+            let projectFinished = components.count > 12 ? (components[12].lowercased() == "true") : false
+            let stageFinished = components.count > 13 ? (components[13].lowercased() == "true") : false
+            let projectFinishDateStr = components.count > 14 ? components[14] : ""
+            let stageFinishDateStr = components.count > 15 ? components[15] : ""
+            let projectFinishDate = dateFormatter.date(from: projectFinishDateStr)
+            let stageFinishDate = dateFormatter.date(from: stageFinishDateStr)
 
             let project: WritingProject
             if let existing = projectsDict[title] {
@@ -118,6 +133,8 @@ struct CSVManager {
             if let shareProgress {
                 project.lastShareProgress = shareProgress
             }
+            project.isFinished = projectFinished
+            project.finishDate = projectFinishDate
 
             var stage: Stage? = nil
             if !stageTitle.isEmpty {
@@ -128,6 +145,10 @@ struct CSVManager {
                     let newStage = Stage(title: stageTitle, goal: stageGoal, deadline: stageDeadline, startProgress: stageStart, order: project.stages.count)
                     project.stages.append(newStage)
                     stage = newStage
+                }
+                stage?.isFinished = stageFinished
+                if let stage {
+                    stage.finishDate = stageFinishDate
                 }
             }
 
@@ -156,6 +177,8 @@ struct CSVManager {
         var deadline: Date?
         var startProgress: Int
         var order: Int
+        var isFinished: Bool?
+        var finishDate: Date?
         var entries: [JSONEntry]
     }
 
@@ -164,6 +187,8 @@ struct CSVManager {
         var goal: Int
         var deadline: Date?
         var lastShareProgress: Int?
+        var isFinished: Bool?
+        var finishDate: Date?
         var entries: [JSONEntry]
         var stages: [JSONStage]
     }
@@ -176,6 +201,8 @@ struct CSVManager {
             goal: project.goal,
             deadline: project.deadline,
             lastShareProgress: project.lastShareProgress,
+            isFinished: project.isFinished,
+            finishDate: project.finishDate,
             entries: project.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) },
             stages: project.stages.enumerated().map { idx, stage in
                 JSONStage(
@@ -184,6 +211,8 @@ struct CSVManager {
                     deadline: stage.deadline,
                     startProgress: stage.startProgress,
                     order: stage.order,
+                    isFinished: stage.isFinished,
+                    finishDate: stage.finishDate,
                     entries: stage.entries.map { JSONEntry(date: $0.date, characterCount: $0.characterCount) }
                 )
             }
@@ -200,9 +229,13 @@ struct CSVManager {
             proj.stages = jp.stages.map { js in
                 let st = Stage(title: js.title, goal: js.goal, deadline: js.deadline, startProgress: js.startProgress, order: js.order)
                 st.entries = js.entries.map { Entry(date: $0.date, characterCount: $0.characterCount) }
+                st.isFinished = js.isFinished ?? false
+                st.finishDate = js.finishDate
                 return st
             }.sorted { $0.order < $1.order }
             proj.lastShareProgress = jp.lastShareProgress
+            proj.isFinished = jp.isFinished ?? false
+            proj.finishDate = jp.finishDate
             return proj
         }
     }

--- a/nfprogress/ContentView.swift
+++ b/nfprogress/ContentView.swift
@@ -55,19 +55,22 @@ struct ContentView: View {
 
 
   private var sortedProjects: [WritingProject] {
+    let active = projects.filter { !$0.isFinished }
     switch settings.projectSortOrder {
     case .title:
-      return projects.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
+      return active.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     case .progress:
-      return projects.sorted { $0.progress > $1.progress }
+      return active.sorted { $0.progress > $1.progress }
     case .deadline:
-      return projects.sorted {
+      return active.sorted {
         let d0 = $0.deadline == nil ? Int.max : $0.daysLeft
         let d1 = $1.deadline == nil ? Int.max : $1.daysLeft
         return d0 < d1
       }
     case .custom:
-      return projects
+      return active
+    case .finished:
+      return projects.filter { $0.isFinished }.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
     }
   }
 

--- a/nfprogress/EntryViews.swift
+++ b/nfprogress/EntryViews.swift
@@ -16,24 +16,32 @@ struct AddEntryView: View {
     /// Текст, введённый пользователем для нового значения прогресса.
     @State private var characterText = ""
 
+    /// Стадии, доступные для добавления записей
+    private var availableStages: [Stage] {
+        project.sortedStages.filter { !$0.isFinished }
+    }
+
     /// Текущий прогресс выбранного этапа или всего проекта.
     private var previousProgress: Int {
         if let fixedStage {
             return fixedStage.currentProgress
         }
-        if project.sortedStages.isEmpty {
+        if availableStages.isEmpty {
             return project.currentProgress
         }
-        let stage = project.sortedStages[min(max(selectedStageIndex, 0), project.sortedStages.count - 1)]
+        let stage = availableStages[min(max(selectedStageIndex, 0), availableStages.count - 1)]
         return stage.currentProgress
     }
 
     init(project: WritingProject, stage: Stage? = nil) {
         self.project = project
         self.fixedStage = stage
+        // При инициализации `availableStages` ещё нельзя обращаться к `self`,
+        // поэтому используем локальный список стадий проекта
+        let stages = project.sortedStages.filter { !$0.isFinished }
         let initialIndex: Int
         if let stage,
-           let found = project.sortedStages.firstIndex(where: { $0.id == stage.id }) {
+           let found = stages.firstIndex(where: { $0.id == stage.id }) {
             initialIndex = found
         } else {
             initialIndex = 0
@@ -51,9 +59,9 @@ struct AddEntryView: View {
             DatePicker("date_time", selection: $date)
                 .labelsHidden()
 
-            if fixedStage == nil && !project.sortedStages.isEmpty {
+            if fixedStage == nil && !availableStages.isEmpty {
                 Picker("stage", selection: $selectedStageIndex) {
-                    ForEach(Array(project.sortedStages.enumerated()), id: \.offset) { idx, stage in
+                    ForEach(Array(availableStages.enumerated()), id: \.offset) { idx, stage in
                         Text(stage.title)
                             .tag(idx)
                     }
@@ -81,6 +89,7 @@ struct AddEntryView: View {
             .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
             .scaledPadding(1, .bottom)
+            .disabled(project.isFinished || fixedStage?.isFinished == true)
         }
         .scaledPadding(1, [.horizontal, .bottom])
         .scaledPadding(2, .top)
@@ -90,7 +99,7 @@ struct AddEntryView: View {
 #endif
         .onChange(of: selectedStageIndex) { newValue in
             guard fixedStage == nil,
-                  project.sortedStages.indices.contains(newValue) else { return }
+                  availableStages.indices.contains(newValue) else { return }
             characterText = ""
         }
     }
@@ -106,11 +115,13 @@ struct AddEntryView: View {
             if let fixedStage {
                 targetStage = fixedStage
             } else {
-                let index = min(max(selectedStageIndex, 0), project.sortedStages.count - 1)
-                targetStage = project.sortedStages[index]
+                let index = min(max(selectedStageIndex, 0), availableStages.count - 1)
+                targetStage = availableStages[index]
             }
             delta = entered - (targetStage?.currentProgress ?? 0)
         }
+
+        guard !project.isFinished, targetStage?.isFinished != true else { return }
 
         let newEntry = Entry(date: date, characterCount: delta)
         dismiss()

--- a/nfprogress/ImportExportView.swift
+++ b/nfprogress/ImportExportView.swift
@@ -164,6 +164,7 @@ struct ImportExportView: View {
                 current.entries = imported.entries
                 current.stages = imported.stages
                 current.lastShareProgress = imported.lastShareProgress
+                current.isFinished = imported.isFinished
 
                 for stage in current.stages {
                     if let old = stageSyncInfo[stage.title] {
@@ -178,6 +179,9 @@ struct ImportExportView: View {
                         stage.lastWordModified = old.lastWordModified
                         stage.lastScrivenerCharacters = old.lastScrivenerCharacters
                         stage.lastScrivenerModified = old.lastScrivenerModified
+                    }
+                    if let importedStage = imported.stages.first(where: { $0.title == stage.title }) {
+                        stage.isFinished = importedStage.isFinished
                     }
                 }
 

--- a/nfprogress/ProjectDetailView.swift
+++ b/nfprogress/ProjectDetailView.swift
@@ -28,6 +28,7 @@ struct ProjectDetailView: View {
     @State private var selectedEntry: Entry?
     @State private var draggedStage: Stage?
     @State private var dropTargetStage: Stage?
+    @State private var showFinishAlert = false
     // Состояние редактирования отдельных полей
     @State private var isEditingGoal = false
     @State private var isEditingDeadline = false
@@ -109,8 +110,10 @@ struct ProjectDetailView: View {
         HStack {
             if !project.stages.isEmpty {
                 Button("add_entry_button") { addEntry() }
+                    .disabled(project.isFinished)
             }
             Button("add_stage") { addStage() }
+                .disabled(project.isFinished)
 #if os(macOS)
             if project.hasStageSync {
                 Button("sync_now_button") { syncAllStages() }
@@ -275,6 +278,7 @@ struct ProjectDetailView: View {
             HStack {
                 Button("add_entry_button") { addEntry() }
                     .keyboardShortcut("n", modifiers: .command)
+                    .disabled(project.isFinished)
 #if os(macOS)
                 Button("sync_now_button") {
                     DocumentSyncManager.syncNow(project: project)
@@ -567,7 +571,7 @@ struct ProjectDetailView: View {
     }
 
     var body: some View {
-        ScrollView {
+        ScrollView(.vertical) {
             LazyVStack(alignment: .leading, spacing: scaledSpacing(1.5)) {
                 infoSection
                 progressCircleSection
@@ -596,6 +600,24 @@ struct ProjectDetailView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .menuAddStage)) { _ in
             addStage()
+        }
+        .alert(settings.localized("finish_project_confirm"), isPresented: $showFinishAlert) {
+            Button(settings.localized("finish")) {
+                let now = Date()
+                for stage in project.stages {
+                    if !stage.isFinished {
+                        stage.isFinished = true
+                        stage.finishDate = now
+                    }
+                }
+                project.isFinished = true
+                project.finishDate = now
+                try? modelContext.save()
+                NotificationCenter.default.post(name: .projectProgressChanged, object: project.id)
+            }
+            Button(settings.localized("cancel"), role: .cancel) { }
+        } message: {
+            Text("finish_project_message")
         }
         .alert(item: $stageToDelete) { stage in
             if project.stages.count == 1 {
@@ -643,6 +665,22 @@ struct ProjectDetailView: View {
                 }
             }
 #endif
+            ToolbarItem(placement: .primaryAction) {
+                if project.isFinished {
+                    if let date = project.finishDate {
+                        let formatter = DateFormatter()
+                        formatter.dateFormat = "dd.MM.yyyy"
+                        Text("\(settings.localized("finished_label")) \(formatter.string(from: date))")
+                    } else {
+                        Text(settings.localized("finished_label"))
+                    }
+                } else {
+                    Button(action: { showFinishAlert = true }) {
+                        Image(systemName: "checkmark")
+                    }
+                    .help(settings.localized("finish_project_tooltip"))
+                }
+            }
         }
         .navigationTitle("")
 #if os(iOS)

--- a/nfprogress/Resources/en.lproj/Localizable.strings
+++ b/nfprogress/Resources/en.lproj/Localizable.strings
@@ -125,3 +125,10 @@
 "import_success" = "Import completed successfully";
 "import_failed" = "Import failed";
 "written_today" = "Written today %d characters";
+"finish_project_confirm" = "Finish this project?";
+"finish_project_message" = "After finishing it, you will only be able to view it.";
+"finish" = "Finish";
+"finish_project_tooltip" = "Finish project";
+"finish_stage_tooltip" = "Finish stage";
+"sort_finished" = "Finished";
+"finished_label" = "Finished";

--- a/nfprogress/Resources/ru.lproj/Localizable.strings
+++ b/nfprogress/Resources/ru.lproj/Localizable.strings
@@ -126,3 +126,10 @@
 "import_success" = "Импорт успешно завершен";
 "import_failed" = "Импорт не состоялся";
 "written_today" = "Написано сегодня %d символов";
+"finish_project_confirm" = "Вы хотите завершить проект?";
+"finish_project_message" = "После завершения его можно будет только просматривать";
+"finish" = "Завершить";
+"finish_project_tooltip" = "Завершить проект";
+"finish_stage_tooltip" = "Завершить этап";
+"sort_finished" = "Завершенные";
+"finished_label" = "Завершен";

--- a/nfprogress/Stage.swift
+++ b/nfprogress/Stage.swift
@@ -36,6 +36,10 @@ class Stage: Identifiable {
     var lastScrivenerModified: Date?
     /// Приостановлена ли синхронизация
     var syncPaused: Bool = false
+    /// Завершён ли этап
+    var isFinished: Bool = false
+    /// Дата завершения этапа
+    var finishDate: Date?
 
     init(title: String, goal: Int, deadline: Date? = nil, startProgress: Int, order: Int = 0) {
         self.title = title
@@ -73,11 +77,15 @@ class Stage: Identifiable {
     var currentProgress: Int {
         guard modelContext != nil else { return 0 }
         let total = sortedEntries.cumulativeProgress()
+        if isFinished {
+            return max(goal, total)
+        }
         return max(0, total)
     }
 
     var progressPercentage: Double {
         guard goal > 0 else { return 0 }
+        if isFinished { return 1.0 }
         let percent = Double(currentProgress) / Double(goal)
         return min(max(percent, 0), 1.0)
     }

--- a/nfprogress/WritingProject.swift
+++ b/nfprogress/WritingProject.swift
@@ -37,6 +37,10 @@ class WritingProject {
     var lastScrivenerModified: Date?
     /// Прогресс в момент последнего шеринга
     var lastShareProgress: Int?
+    /// Завершён ли проект
+    var isFinished: Bool = false
+    /// Дата завершения проекта
+    var finishDate: Date?
 
     init(title: String, goal: Int, deadline: Date? = nil, order: Int = 0, isChartCollapsed: Bool = false) {
         self.title = title
@@ -109,8 +113,24 @@ class WritingProject {
     }
 
     var currentProgress: Int {
-        guard let last = sortedEntries.last else { return 0 }
-        return globalProgress(for: last)
+        let base: Int
+        if let last = sortedEntries.last {
+            base = globalProgress(for: last)
+        } else {
+            base = 0
+        }
+
+        let stageBonus = stages.reduce(0) { partial, stage in
+            guard stage.isFinished else { return partial }
+            let written = stage.startProgress + stage.sortedEntries.cumulativeProgress()
+            return partial + max(stage.goal - written, 0)
+        }
+
+        var total = base + stageBonus
+        if isFinished {
+            total = max(total, goal)
+        }
+        return total
     }
 
     var previousProgress: Int {
@@ -137,6 +157,7 @@ class WritingProject {
     /// Общий прогресс проекта в диапазоне 0...1
     var progress: Double {
         guard goal > 0 else { return 0 }
+        if isFinished { return 1.0 }
         return min(Double(currentProgress) / Double(goal), 1.0)
     }
 


### PR DESCRIPTION
## Summary
- automatically complete all stages when project finishes
- save completion dates for projects and stages
- show completion date in toolbar instead of icon
- include finish dates in CSV and JSON import/export
- fix JSON export initializer ordering
- fix ScrollView initializer for compatibility

## Testing
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_6870f9044a808333973467f253b3d94d